### PR TITLE
Improved filtering

### DIFF
--- a/src/blockchainAPI/steemAPI.ts
+++ b/src/blockchainAPI/steemAPI.ts
@@ -11,13 +11,13 @@ export class SteemAPI {
         return new Promise((resolve, reject) => {
             steem.api.getDiscussionsByCreated({
                 "tag": tag,
-                "limit": 10
+                "limit": 100
             }, (err, result) => {
                 if (err) {
                     reject(err)
                 } else {
                     resolve(result
-                        .filter(x => x.category === tag)
+                        // .filter(x => x.category === tag)
                         .map(post => ({
                             author: post.author,
                             permlink: post.permlink,
@@ -25,6 +25,7 @@ export class SteemAPI {
                             votes: post.active_votes.length,
                             did_comment: false,
                             did_vote: false,
+                            is_approved: false,
                         }) as Post)
                     )
                 }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -3,14 +3,18 @@ import { Database } from './database/database'
 import { BlockchainAPI } from './blockchainAPI/blockchainAPI'
 import { User } from './classes/user';
 import { weekFilter } from './filters';
+import { Post } from './classes/post';
+import { cleanScrape } from './functions';
 
 const steem = require('steem')
 
 export class Bot {
-    week: number;          // 5
+    week: number;
     communityName: string; // nowplaying
     username: string;      // nowplaying-music
     password: string;
+    users: User[];
+    posts: Post[];
 
     private _broadcaster: Broadcaster;
     private _blockchainAPI: BlockchainAPI;
@@ -37,25 +41,51 @@ export class Bot {
     async setDatabase(database: Database): Promise<void> {
         this._database = database
         await this._database.setup()
+        this.users = await this._database.getUsers()
     }
 
     async scrape(): Promise<any> {
         try {
-            console.log(this._blockchainAPI)
-            const posts = await this._blockchainAPI.getPosts(this.communityName)
-            const write = await this._database.writePosts(posts, async post => {
-                try {
-                    const comment = await this._broadcaster.makeComment(post)
-                } catch(e) { }
-                try {
-                    const vote = await this._broadcaster.makeVote(post)
-                } catch(e) { }
-                return { }
-            })
-            console.log(write)
+            const x = await this._blockchainAPI.getPosts(this.communityName)
+            const posts = await cleanScrape(x, this.users)
+            console.log(await this._database.writePosts(posts))
         } catch(e) {
             console.log(e)
             console.log('got err')
+        }
+    }
+
+    async comment(): Promise<any> {
+        try {
+            const allPosts = await this._database.getPosts()
+            const toCommentPosts = allPosts.filter(post => !post.did_comment)
+            
+            // Comment on each one with 20 second breaks
+            toCommentPosts.forEach((post, index) => {
+                setTimeout(() => {
+                    this._broadcaster.makeComment(post)
+                    this._database.writeComment(post)
+                }, index * 22 * 1000)
+            })
+        } catch(e) {
+            console.log('something went wrong', e)
+        }
+    }
+    
+    async vote(): Promise<any> {
+        try {
+            const allPosts = await this._database.getPosts()
+            const toVotePosts = allPosts.filter(post => !post.did_vote)
+            
+            // Comment on each one with 20 second breaks
+            toVotePosts.forEach((post, index) => {
+                setTimeout(() => {
+                    this._broadcaster.makeVote(post)
+                    this._database.writeVote(post)
+                }, index * 22 * 1000)
+            })
+        } catch(e) {
+            console.log('something went wrong', e)
         }
     }
 

--- a/src/classes/post.ts
+++ b/src/classes/post.ts
@@ -13,6 +13,7 @@ export class Post {
     // SQL
     did_comment: boolean;
     did_vote: boolean;
+    is_approved: boolean;
 
     constructor() {
         this.jsonMetadata = {} as JsonMetadata

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -5,5 +5,8 @@ export interface Database {
     setup: () => Promise<void>
     getUsers: () => Promise<User[]>
     getPosts: () => Promise<Post[]>
-    writePosts: (posts: Post[], onInsert: (post: Post) => Promise<any>) => Promise<{ created: number, updated: number, total: number }>
+    
+    writePosts: (posts: Post[]) => Promise<{ created: number, updated: number, total: number }>
+    writeComment: (post: Post) => Promise<any>
+    writeVote: (post: Post) => Promise<any>
 }

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -1,0 +1,12 @@
+import { Post } from './classes/post';
+import { User } from './classes/user';
+import { Settings } from './settings'
+
+export const cleanScrape = (posts: Post[], users: User[]): Post[] => posts
+    .filter(post => !Settings.blacklist.includes(post.author))
+    .map(post => {
+        if (users.map(u => u.username).includes(post.author)) {
+            post.is_approved = true
+        }
+        return post
+    })

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,11 +24,15 @@ const main = async () => {
   bot.setBlockchainAPI(new SteemAPI())
   await bot.setDatabase(new sqlDatabase(local))
   // bot.scrape()
-  bot.comment()
-  bot.vote()
+  
+  
+  // every minute scrape, vote, and comment
+  setInterval(() => {
+    bot.scrape()
+    bot.vote()
+    bot.comment()
+  }, 1000 * 60)
 
-  // bot.scrape()
-  // setInterval(() => bot.scrape(), 1000 * 60) // every minute
   // const payout = await bot.payout(1.425)
   // console.log(payout)
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,9 +7,9 @@ import { SteemAPI } from './blockchainAPI/steemAPI';
 const mysql = require('promise-mysql');
 
 const local = {
-  host: 'localhost',
-  user: 'root', //process.env.DB_USER,
-  password: 'password', //process.env.DB_PASS,
+  host: '192.168.0.2',
+  user: 'nodice', //process.env.DB_USER,
+  password: '', //process.env.DB_PASS,
   database: 'nowplaying'
 };
 
@@ -24,8 +24,12 @@ const main = async () => {
   bot.setBlockchainAPI(new SteemAPI())
   await bot.setDatabase(new sqlDatabase(local))
   // bot.scrape()
+  bot.comment()
+  bot.vote()
+
+  // bot.scrape()
   // setInterval(() => bot.scrape(), 1000 * 60) // every minute
-  const payout = await bot.payout(1.425)
+  // const payout = await bot.payout(1.425)
   // console.log(payout)
 }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,18 @@
+export const Settings = {
+    week: 6,
+    blacklist: [
+        'nowplaying-music',
+        
+        'arsaljr',
+        'clicknpict',
+        'dianasteem7',
+        'heroheri',
+        'loubega',
+        'maulinda',
+        'rahmatz',
+        'ryanananda',
+        'safrizalpotret',
+        'tasyazgs588',
+    ]
+
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "compilerOptions": {
+    "lib": [
+      "dom",
+      "es7"
+    ],
     "target": "es6",
     "module": "commonjs",
     "moduleResolution": "node",


### PR DESCRIPTION
### Bug Fixes
A huge issue this week with the nowplaying bot was there were many people tagging #nowplaying but not actually participating in the nowplaying community.  The first fix made was changing the filtering from `post.tags.includes(communityName)` to `post.category === communityName`.

The results were better, but now there are some community members posting under `music` or another category and using `nowplaying` as a tag.  The solution here is to begin approving authors.  The `post` table in the database now includes a `is_approved` flag.  Any author who has been approved in the past is automatically approved.There is a blacklist that will filter out people from unrelated topics or people abusing the bot.

This still leaves the new members who have legitimate posts and spammers using this tag.  Anybody who follows a certain criteria can be automatically approved.  For example: the #nowplaying bot posts weekly to start off the week.  Any user who likes that post can be automatically approved.  This leaves all community members and filters out unrelated content.

### New Features
Commenting and Voting are now separate functions than the `scrape` function, and they are more aware.  The `did_comment` and `did_vote` boolean columns in the database are used to keep track of which posts have been voted/commented on and which haven't.  These can be run independently now, so you can have the bot comment on all posts (including spam) and only upvote approved content.

### Now Playing
Check out the #nowplaying community and bot in action [here](https://steemit.com/nowplaying/@nowplaying-music/now-playing-week-6)
