### PR TITLE
Individual Processes

### DIFF
--- a/src/blockchainAPI/steemAPI.ts
+++ b/src/blockchainAPI/steemAPI.ts
@@ -18,6 +18,7 @@ export class SteemAPI {
                         .map(post => ({
                             author: post.author,
                             permlink: post.permlink,
+                            tag: post.category,
                             created: post.created,
                             votes: post.active_votes.length,
                             did_comment: false,

--- a/src/broadcaster/steemBroadcaster.ts
+++ b/src/broadcaster/steemBroadcaster.ts
@@ -1,6 +1,4 @@
 import { Post } from '../classes/post';
-import { Wallet } from '../classes/wallet';
-import { sqlDatabase } from '../database/sqlDatabase';
 
 const steem = require('steem')
 export class SteemBroadcaster {

--- a/src/classes/post.ts
+++ b/src/classes/post.ts
@@ -4,6 +4,7 @@ export class Post {
     // STEEM
     author: string;
     permlink: string;
+    tag: string;
     created: string;
     title: string;
     body: string;

--- a/src/database/sqlDatabase.ts
+++ b/src/database/sqlDatabase.ts
@@ -24,6 +24,7 @@ export class sqlDatabase {
                 votes: data.votes,
                 created: data.created,
                 permlink: data.permlink,
+                tag: data.tag,
                 did_comment: data.did_comment,
                 did_vote: data.did_vote,
                 is_approved: data.is_approved
@@ -48,6 +49,7 @@ export class sqlDatabase {
         return posts.map(d => ({
             author: d.author,
             permlink: d.permlink,
+            tag: d.tag,
             votes: d.votes,
             created: d.created,
             did_comment: d.did_comment,
@@ -66,6 +68,7 @@ export class sqlDatabase {
                 try {
                     result = await this._con.query('INSERT INTO posts SET ?', [post])
                 } catch (e) {
+                    // Integrity error - this post already exists
                     // console.log('error inserting prolly cause im there already')
                 }
                 return {

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -1,5 +1,1 @@
-import { Post } from './classes/post';
-import { User } from './classes/user';
-import { settings } from './settings'
-
 export const getWeek = (date: Date) => Math.ceil((((date.getTime() - new Date(2018, 0, 1).getTime()) / 86400000) + 1) / 7)

--- a/src/process/init.ts
+++ b/src/process/init.ts
@@ -1,8 +1,10 @@
-import { Bot } from './bot';
-import { SteemBroadcaster } from './broadcaster/steemBroadcaster';
-import { sqlDatabase } from './database/sqlDatabase';
-import { SteemAPI } from './blockchainAPI/steemAPI';
-import { settings } from './settings';
+// initializes the bot to run the process
+
+import { Bot } from '../bot';
+import { SteemBroadcaster } from '../broadcaster/steemBroadcaster';
+import { sqlDatabase } from '../database/sqlDatabase';
+import { SteemAPI } from '../blockchainAPI/steemAPI';
+import { settings } from '../settings';
 
 const local = {
   host: process.env.DB_HOST,
@@ -11,8 +13,7 @@ const local = {
   database: settings.communityName
 };
 
-const main = async () => {
-  // const TIME = 1000 * 60 * 30
+export const init = async () => {
   const bot = new Bot()
   bot.communityName = settings.communityName
   bot.week = settings.week
@@ -21,11 +22,5 @@ const main = async () => {
   bot.setBroadcaster(new SteemBroadcaster())
   bot.setBlockchainAPI(new SteemAPI())
   await bot.setDatabase(new sqlDatabase(local))
-  bot.postWeek()
-  // every minute scrape, vote, and comment
-  // setInterval(() => { bot.scrape(); }, TIME)
-  
-  // bot.scrape()
+  return bot
 }
-
-main()

--- a/src/process/payout.ts
+++ b/src/process/payout.ts
@@ -1,0 +1,10 @@
+import { init } from './init'
+import { Bot } from '../bot';
+import { settings } from '../settings';
+
+const main = async () => {
+    const bot: Bot = await init()
+    bot.payout(settings.payout)
+}
+
+main()

--- a/src/process/postRecap.ts
+++ b/src/process/postRecap.ts
@@ -5,7 +5,7 @@ const ncp = require('copy-paste')
 const main = async () => {
     const bot: Bot = await init()
     const report = await bot.postRecap()
-    console.log(report)
+    // console.log(report)
     ncp.copy(report.post.body, () => console.log('Copied to clipboard'))
 }
 

--- a/src/process/postRecap.ts
+++ b/src/process/postRecap.ts
@@ -1,0 +1,12 @@
+import { init } from './init'
+import { Bot } from '../bot';
+const ncp = require('copy-paste')
+
+const main = async () => {
+    const bot: Bot = await init()
+    const report = await bot.postRecap()
+    console.log(report)
+    ncp.copy(report.post.body, () => console.log('Copied to clipboard'))
+}
+
+main()

--- a/src/process/postWeek.ts
+++ b/src/process/postWeek.ts
@@ -1,0 +1,12 @@
+import { init } from './init'
+import { Bot } from '../bot';
+const ncp = require('copy-paste')
+
+const main = async () => {
+    const bot: Bot = await init()
+    const report = await bot.postWeek()
+    console.log(report)
+    ncp.copy(report.post.body, () => console.log('Copied to clipboard'))
+}
+
+main()

--- a/src/process/postWeek.ts
+++ b/src/process/postWeek.ts
@@ -5,7 +5,7 @@ const ncp = require('copy-paste')
 const main = async () => {
     const bot: Bot = await init()
     const report = await bot.postWeek()
-    console.log(report)
+    // console.log(report)
     ncp.copy(report.post.body, () => console.log('Copied to clipboard'))
 }
 

--- a/src/process/scrape.ts
+++ b/src/process/scrape.ts
@@ -1,0 +1,10 @@
+import { init } from './init'
+import { Bot } from '../bot';
+
+
+const main = async () => {
+    const bot: Bot = await init()
+    bot.scrape()
+}
+
+main()

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -93,7 +93,7 @@ const leaderboard = (report: Report): Report => {
 
 export const reportRecap = (_users) => {
     const report = new Report()
-    report.reportOptions.week = settings.week
+    report.reportOptions.week = settings.week - 1
     report.reportOptions.startWeek = new Date(2018, 0, (report.reportOptions.week - 1) * 7)
     report.reportOptions.endWeek = new Date(2018, 0, (report.reportOptions.week) * 7 - 1)
     report.reportOptions.payout = settings.payout

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -1,6 +1,5 @@
 import { getWeek } from './functions';
 import { Post } from './classes/post';
-import { User } from './classes/user';
 import { weekFilter } from './filters';
 
 const dateformat = require('dateformat')
@@ -28,7 +27,7 @@ const getRankings = (report: Report): string => report.users
     // Reduce into one large string
     .reduce((str, user, index) => `${str}\n${index+1} | ${user.username} | ${user.weeks} | ${user.votes}`, '')
 
-export const playerStats = (users: User[], username: string) => getRankings({ users, reportOptions: { week: 5}} as Report).find(x => x.author === username).text
+// export const playerStats = (users: User[], username: string) => getRankings({ users, reportOptions: { week: 5}} as Report).find(x => x.author === username).text
     // getRankings({users, reportOptions: {week: 5}} as Report).find(str => str.includes(`@${username}`))
 
 const center = (str: string) => `<center>${str}</center>`

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2,7 +2,7 @@ export const settings = {
     communityName: 'nowplaying',
     username: process.env.STEEM_USERNAME,
     password: process.env.STEEM_PASSWORD,
-    week: Math.ceil((((new Date() - new Date(2018, 0, 1)) / 86400000) ) / 7),
+    week: Math.ceil(((((new Date() as any) - (new Date(2018, 0, 1) as any)) / 86400000) ) / 7),
     payout: 0.580,
     tags: ['nowplaying', 'music', 'contest', 'share', 'spotify'],
     blacklist: [


### PR DESCRIPTION
- Linting
- individual processes
- Tag column added to database

### Bug Fixes/Small Things
#### Linting
The entire codebase was linted so the production build no compiles.  There were small errors throughout the codebase like unused imports and a type error when doing `(new Date() - new Date(2018, 1, 1)`.  You may now run `npm run build`.

#### Tag Column
Although the steem blockchain only considers posts unique by their `author` and `permlink`, a tag is still needed on sites like `busy.org` and `steemit.com` because the url for a given post is something like `<domain>/<tag>/<author>/<permlink>`.  I also cannot assume that the tag is always going to be `nowplaying` because some authors will not follow the rules 100%.  I am now keeping track of the `tag` field in the database which will be used when displaying all contestants and their posts.

### New Features
#### Processes
In the past there was a `main` function that would always have to be edited.  With this pull request there is a new folder `/src/process` which holds files that do one thing: that process.  There are three process files currently:
- scrape (includes approve, comment, vote)
- postWeek
- postRecap
- payout

This leaves a single executable javascript file with one purpose.  This will be very useful for scripts and cron jobs.  It is a step towards scheduling the weekly recap and new week posts.


### Now Playing
Check out the #nowplaying community and bot in action [here](https://steemit.com/nowplaying/@nowplaying-music/now-playing-week-9)
![](https://steemit-production-imageproxy-upload.s3.amazonaws.com/DQmSWxfGJgRD6XR7grLHWAEvM35ZmoPzNfQ3YAr6eVjhBvd)