### PR TITLE
Spotify stats

### DIFF
--- a/src/blockchainAPI/steemAPI.ts
+++ b/src/blockchainAPI/steemAPI.ts
@@ -9,7 +9,7 @@ export class SteemAPI {
         return new Promise((resolve, reject) => {
             steem.api.getDiscussionsByCreated({
                 "tag": tag,
-                "limit": 30
+                "limit": 15
             }, (err, result) => {
                 if (err) {
                     reject(err)
@@ -18,8 +18,8 @@ export class SteemAPI {
                         .map(post => ({
                             author: post.author,
                             permlink: post.permlink,
-                            tag: post.category,
-                            created: post.created,
+                            tag: post.category.replace(/\W/g, ''),
+                            created: new Date(2018, 3, 9),
                             votes: post.active_votes.length,
                             did_comment: false,
                             did_vote: false,

--- a/src/blockchainAPI/steemAPI.ts
+++ b/src/blockchainAPI/steemAPI.ts
@@ -9,7 +9,7 @@ export class SteemAPI {
         return new Promise((resolve, reject) => {
             steem.api.getDiscussionsByCreated({
                 "tag": tag,
-                "limit": 15
+                "limit": 30
             }, (err, result) => {
                 if (err) {
                     reject(err)
@@ -19,7 +19,7 @@ export class SteemAPI {
                             author: post.author,
                             permlink: post.permlink,
                             tag: post.category.replace(/\W/g, ''),
-                            created: new Date(2018, 3, 9),
+                            created: post.created,
                             votes: post.active_votes.length,
                             did_comment: false,
                             did_vote: false,

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -129,7 +129,6 @@ export class Bot {
     async payout(totalPayout: number): Promise<any> {
         const allUsers = await this._database.getUsers()
         const weekUsers = allUsers.filter(weekFilter(this.week))
-
         const wallet = await this._blockchainAPI.getWallet({ username: this.username } as User)
         wallet.setActive(this.getActiveWif())
 

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -198,11 +198,5 @@ export class Bot {
                 }
             })
         })
-        console.log(playlists)
-        let track = playlists[0].tracks[0]
-        this._database.writeTrack(track)
-        track = playlists[0].tracks[1]
-        this._database.writeTrack(track)
-
     }
 }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -7,6 +7,7 @@ import { weekFilter } from './filters';
 import { Statistics } from './statistics';
 import { Post } from './classes/post';
 import { Report } from './classes/report';
+import { Spotify } from './process/spotify';
 const dateformat = require('dateformat')
 
 const steem = require('steem')
@@ -182,5 +183,26 @@ export class Bot {
         statistics.users = await this._database.getUsers()
 
         statistics.general()
+    }
+
+    async spotify() {
+        const spotify = Spotify.Instance()
+        const playlists = await spotify.getPlaylists()
+        playlists.forEach(playlist => {
+            playlist.tracks.forEach(async track => {
+                try {
+                    await this._database.writeTrack(track)
+                } catch(e) {
+                    console.log(`couldn't write track ${track.name} due to ${e}`)
+                    console.warn(e)
+                }
+            })
+        })
+        console.log(playlists)
+        let track = playlists[0].tracks[0]
+        this._database.writeTrack(track)
+        track = playlists[0].tracks[1]
+        this._database.writeTrack(track)
+
     }
 }

--- a/src/classes/playlist.ts
+++ b/src/classes/playlist.ts
@@ -3,5 +3,6 @@ import { Track } from './track'
 export class Playlist {
     id: string;
     name: string;
+    week: number;
     tracks: Track[];
 }

--- a/src/classes/playlist.ts
+++ b/src/classes/playlist.ts
@@ -1,0 +1,7 @@
+import { Track } from './track'
+
+export class Playlist {
+    id: string;
+    name: string;
+    tracks: Track[];
+}

--- a/src/classes/track.ts
+++ b/src/classes/track.ts
@@ -1,14 +1,15 @@
 export class Track {
-    id: string;
+    spotify_id: string;
     name: string;
+    week: number;
     artists: string[];
 
     public print() {
         const artistStr = this.artists.reduce((prev, current, index) => index ? `${current}` : `${prev},-${current}`)
-        console.log(`${artistStr} - ${this.name}`)
+        console.log(`${this.week}: ${artistStr} - ${this.name}`)
     }
     public toString() {
         const artistStr = this.artists.reduce((prev, current, index) => index ? `${current}` : `${prev},-${current}`)
-        return `${artistStr} - ${this.name}`
+        return `${this.week}: ${artistStr} - ${this.name}`
     }
 }

--- a/src/classes/track.ts
+++ b/src/classes/track.ts
@@ -1,0 +1,14 @@
+export class Track {
+    id: string;
+    name: string;
+    artists: string[];
+
+    public print() {
+        const artistStr = this.artists.reduce((prev, current, index) => index ? `${current}` : `${prev},-${current}`)
+        console.log(`${artistStr} - ${this.name}`)
+    }
+    public toString() {
+        const artistStr = this.artists.reduce((prev, current, index) => index ? `${current}` : `${prev},-${current}`)
+        return `${artistStr} - ${this.name}`
+    }
+}

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -1,5 +1,6 @@
 import { User } from '../classes/user';
 import { Post } from '../classes/post';
+import { Track } from '../classes/track';
 
 export interface Database {
     setup: () => Promise<void>
@@ -10,4 +11,5 @@ export interface Database {
     writePosts: (posts: Post[]) => Promise<{ created: number, updated: number, total: number }>
     writeComment: (post: Post) => Promise<any>
     writeVote: (post: Post) => Promise<any>
+    writeTrack: (track: Track) => Promise<any>
 }

--- a/src/database/sqlDatabase.ts
+++ b/src/database/sqlDatabase.ts
@@ -1,6 +1,7 @@
 import { settings } from './../settings';
 import { User } from '../classes/user';
 import { Post } from '../classes/post';
+import { Track } from '../classes/track';
 
 const mysql = require('promise-mysql')
 
@@ -110,6 +111,12 @@ export class sqlDatabase {
     async writeVote(post: Post): Promise<any> {
         const result = await this._con.query('UPDATE posts SET did_vote=1 WHERE author=? AND permlink=?', [post.author, post.permlink])
         // console.log(result)
+        return result
+    }
+
+    async writeTrack(track: Track): Promise<any> {
+        const result = await this._con.query('INSERT INTO tracks SET ?', [track])
+        console.log(result)
         return result
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,8 @@ const main = async () => {
   bot.setBroadcaster(new SteemBroadcaster())
   bot.setBlockchainAPI(new SteemAPI())
   await bot.setDatabase(new sqlDatabase(local))
-  bot.postWeek()
+  // bot.postWeek()
+  bot.spotify()
   // every minute scrape, vote, and comment
   // setInterval(() => { bot.scrape(); }, TIME)
   

--- a/src/process/init.ts
+++ b/src/process/init.ts
@@ -7,8 +7,7 @@ import { SteemAPI } from '../blockchainAPI/steemAPI';
 import { settings } from '../settings';
 
 const local = {
-  // host: process.env.DB_HOST,
-  host: '216.15.29.240',
+  host: process.env.DB_HOST,
   user: process.env.DB_USER,
   password: process.env.DB_PASS,
   database: settings.communityName

--- a/src/process/init.ts
+++ b/src/process/init.ts
@@ -7,7 +7,8 @@ import { SteemAPI } from '../blockchainAPI/steemAPI';
 import { settings } from '../settings';
 
 const local = {
-  host: process.env.DB_HOST,
+  // host: process.env.DB_HOST,
+  host: '216.15.29.240',
   user: process.env.DB_USER,
   password: process.env.DB_PASS,
   database: settings.communityName

--- a/src/process/spotify.ts
+++ b/src/process/spotify.ts
@@ -77,20 +77,20 @@ export class Spotify {
 
 
 
-        // const songs = playlists
-        //     .reduce((songs, playlist) => songs.concat(playlist.tracks.map(track => track.artists[0])), [])
-            // .reduce((obj, song) => {
-            //     if (obj[song]) {
-            //         obj[song] += 1
-            //     } else {
-            //         obj[song] = 1
-            //     }
-            //     return obj
-            // }, {})
-            // .sort((a, b) => a > b ? 1 : -1)
-        // console.log(songs)
+        const songs = playlists
+            .reduce((songs, playlist) => songs.concat(playlist.tracks.map(track => track.artists[0])), [])
+            .reduce((obj, song) => {
+                if (obj[song]) {
+                    obj[song] += 1
+                } else {
+                    obj[song] = 1
+                }
+                return obj
+            }, {})
+            .sort((a, b) => a > b ? 1 : -1)
+        console.log(songs)
         
-        // const playlist_songs = playlists.map(playlist => playlist.tracks.map(track => track.toString()))
-        // console.log(playlist_songs)
+        const playlist_songs = playlists.map(playlist => playlist.tracks.map(track => track.toString()))
+        console.log(playlist_songs)
     }
 }

--- a/src/process/spotify.ts
+++ b/src/process/spotify.ts
@@ -1,20 +1,68 @@
 const request = require('request-promise-native')
+import { Playlist } from '../classes/playlist'
+import { Track } from '../classes/track';
+
 const user = '1240132288';
-const playlist = '6NFODPrTH7nLylJS78DDlF';
-const url = `https://api.spotify.com/v1/users/${user}/playlists/${playlist}`
+const urls = {
+    tracks: (userId, playlistId) => `https://api.spotify.com/v1/users/${userId}/playlists/${playlistId}/tracks`,
+    playlists: (userId, playlistId?: number) => `https://api.spotify.com/v1/users/${userId}/playlists/?limit=50`
+}
 const headers = {
     'Accept': 'application/json',
     'Content-Type': 'application/json',
-    'Authorization': 'Bearer BQALYD-FMpB3OQLQcJ-syCnEuT9-uHhjTxZvwBpSsRszFuiiiQNIZWF06BHuEvT7BxG-bBUddQLv-SEW6RAcVOASDEs0OrdhD8BXQrBLoY-3Sy-onrliEfy_qOyBbLaOBFb9M2CY7wma0IppXh26C7ZB2e95RKQ'
+    'Authorization': 'Bearer BQCvp-Z0taIPvaCQJQ-hgctBkgnnXxj9zRNAgdfvHyv0eAR8raygQqs5WrfMNCBIasjej5sc5B0lLZ9iDISFDhcx4bmcoXW0XKbAAgO5LuaKbR6uJtofCMKOdbzs1-3iBfupfj_drytxvmbGYs6lRzybPVWh_qM'
+}
+
+const getTracks = async (playlist: Playlist) => {
+    const response = JSON.parse(await request({ url: urls.tracks(user, playlist.id), headers }))
+    playlist.tracks = response.items
+        .map(item => item.track)
+        .map(item => ({ id: item.id, name: item.name, artists: item.artists.map(a => a.name)}))
+    
+    return playlist
+    
+}
+
+const getPlaylists = async () => {
+    const response = JSON.parse(await request({ url: urls.playlists(user), headers }))
+    const playlistPromises = response.items
+        .filter(item => item.name.includes('#nowplaying'))
+        .map((item): Playlist => ({ id: item.id, name: item.name } as Playlist))
+        .map(playlist => getTracks(playlist)) as Promise<Playlist>[]
+    const playlists = await Promise.all(playlistPromises)
+
+    return playlists
 }
 
 const main = async () => {
-    const response = JSON.parse(await request({ url, headers }))
-    const songs = response.tracks.items.map(item => ({
-        name: item.track.name,
-        artists: item.track.artists.map(artist => artist.name)
-    }))
-    console.log(songs.map(song => `${song.artists}: ${song.name}`).reduce((prev, curr) => `${prev}\n${curr}`))
+    const playlists = (await getPlaylists()).map(playlist => {
+        const ret = new Playlist()
+        ret.id = playlist.id,
+        ret.name = playlist.name,
+        ret.tracks = playlist.tracks.map(track => {
+            const trackRet = new Track()
+            trackRet.id = track.id,
+            trackRet.name = track.name,
+            trackRet.artists = track.artists
+            return trackRet
+        })
+        return ret
+    })
+    const songs = playlists
+        .reduce((songs, playlist) => songs.concat(playlist.tracks.map(track => track.toString())), [])
+        .reduce((obj, song) => {
+            if (obj[song]) {
+                obj[song] += 1
+            } else {
+                obj[song] = 1
+            }
+            return obj
+        })
+        // .sort((a, b) => a > b ? 1 : -1)
+    console.log(songs)
+    
+    const playlist_songs = playlists.map(playlist => playlist.tracks.map(track => track.toString()))
+    // console.log(playlist_songs)
 }
 
 main()

--- a/src/process/spotify.ts
+++ b/src/process/spotify.ts
@@ -2,67 +2,95 @@ const request = require('request-promise-native')
 import { Playlist } from '../classes/playlist'
 import { Track } from '../classes/track';
 
-const user = '1240132288';
-const urls = {
-    tracks: (userId, playlistId) => `https://api.spotify.com/v1/users/${userId}/playlists/${playlistId}/tracks`,
-    playlists: (userId, playlistId?: number) => `https://api.spotify.com/v1/users/${userId}/playlists/?limit=50`
-}
-const headers = {
-    'Accept': 'application/json',
-    'Content-Type': 'application/json',
-    'Authorization': 'Bearer BQCvp-Z0taIPvaCQJQ-hgctBkgnnXxj9zRNAgdfvHyv0eAR8raygQqs5WrfMNCBIasjej5sc5B0lLZ9iDISFDhcx4bmcoXW0XKbAAgO5LuaKbR6uJtofCMKOdbzs1-3iBfupfj_drytxvmbGYs6lRzybPVWh_qM'
-}
+export class Spotify {
+    private static spotify: Spotify = null;
+    private _user: string = '1240132288'
+    private _urls = {
+        tracks: (userId, playlistId) => `https://api.spotify.com/v1/users/${userId}/playlists/${playlistId}/tracks`,
+        playlists: (userId, playlistId?: number) => `https://api.spotify.com/v1/users/${userId}/playlists/?limit=50`
+    }
+    private _headers = {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer BQCFiQxOtRSuuE60u8jSq_LrvRoMnDySwxe17B4O5-NnAS-xLeON2xXeMliJATyVeE-XzA_xWv2mV-uKyo84GivVJ88NuIjgzdvr6YhjfA0oVxwlpX_y0qFCH3ECePmAgS2K2K4kZABQiBwW4PwFL2RHhq7TnY0'
+    }
 
-const getTracks = async (playlist: Playlist) => {
-    const response = JSON.parse(await request({ url: urls.tracks(user, playlist.id), headers }))
-    playlist.tracks = response.items
-        .map(item => item.track)
-        .map(item => ({ id: item.id, name: item.name, artists: item.artists.map(a => a.name)}))
-    
-    return playlist
-    
-}
+    private constructor() { }
 
-const getPlaylists = async () => {
-    const response = JSON.parse(await request({ url: urls.playlists(user), headers }))
-    const playlistPromises = response.items
-        .filter(item => item.name.includes('#nowplaying'))
-        .map((item): Playlist => ({ id: item.id, name: item.name } as Playlist))
-        .map(playlist => getTracks(playlist)) as Promise<Playlist>[]
-    const playlists = await Promise.all(playlistPromises)
+    public static Instance(): Spotify {
+        // check if an instance of the class is already created
+        if (this.spotify == null) {
+            // If not created create an instance of the class
+            // store the instance in the variable
+            this.spotify = new Spotify();
+        }
+        // return the singleton object
+        return this.spotify
+        }
 
-    return playlists
-}
+    /**
+     * This function will mutate the playlist param and populate with tracks
+     * @param playlist gets the tracks for a playlist
+     */
+    private getTracks = async (playlist: Playlist) => {
+        const response = JSON.parse(await request({ url: this._urls.tracks(this._user, playlist.id), headers: this._headers }))
+        playlist.tracks = response.items
+            .map(item => item.track)
+            .map(item => ({
+                spotify_id: item.id,
+                name: item.name,
+                artists: item.artists.map(a => a.name),
+                week: playlist.week
+            }))
+        
+        return playlist
+        
+    }
 
-const main = async () => {
-    const playlists = (await getPlaylists()).map(playlist => {
-        const ret = new Playlist()
-        ret.id = playlist.id,
-        ret.name = playlist.name,
-        ret.tracks = playlist.tracks.map(track => {
-            const trackRet = new Track()
-            trackRet.id = track.id,
-            trackRet.name = track.name,
-            trackRet.artists = track.artists
-            return trackRet
+    public getPlaylists = async () => {
+        const response = JSON.parse(await request({ url: this._urls.playlists(this._user), headers: this._headers }))
+        const playlistPromises = response.items
+            .filter(item => item.name.includes('#nowplaying'))
+            .map(item => Object.assign({}, item, { week: parseInt(item.name.split('#nowplaying')[1]) }))
+            .map((item): Playlist => ({ id: item.id, name: item.name, week: item.week } as Playlist))
+            .map(playlist => this.getTracks(playlist)) as Promise<Playlist>[]
+        const playlists = await Promise.all(playlistPromises)
+
+        return playlists
+    }
+
+    public test = async () => {
+        const playlists = (await this.getPlaylists()).map(playlist => {
+            const ret = new Playlist()
+            ret.id = playlist.id,
+            ret.name = playlist.name,
+            ret.tracks = playlist.tracks.map(track => {
+                const trackRet = new Track()
+                trackRet.spotify_id = track.spotify_id,
+                trackRet.name = track.name,
+                trackRet.artists = track.artists
+                return trackRet
+            })
+            return ret
         })
-        return ret
-    })
-    const songs = playlists
-        .reduce((songs, playlist) => songs.concat(playlist.tracks.map(track => track.toString())), [])
-        .reduce((obj, song) => {
-            if (obj[song]) {
-                obj[song] += 1
-            } else {
-                obj[song] = 1
-            }
-            return obj
-        })
-        // .sort((a, b) => a > b ? 1 : -1)
-    console.log(songs)
-    
-    const playlist_songs = playlists.map(playlist => playlist.tracks.map(track => track.toString()))
-    // console.log(playlist_songs)
-}
 
-main()
+
+
+
+        // const songs = playlists
+        //     .reduce((songs, playlist) => songs.concat(playlist.tracks.map(track => track.artists[0])), [])
+            // .reduce((obj, song) => {
+            //     if (obj[song]) {
+            //         obj[song] += 1
+            //     } else {
+            //         obj[song] = 1
+            //     }
+            //     return obj
+            // }, {})
+            // .sort((a, b) => a > b ? 1 : -1)
+        // console.log(songs)
+        
+        // const playlist_songs = playlists.map(playlist => playlist.tracks.map(track => track.toString()))
+        // console.log(playlist_songs)
+    }
+}

--- a/src/process/spotify.ts
+++ b/src/process/spotify.ts
@@ -1,0 +1,20 @@
+const request = require('request-promise-native')
+const user = '1240132288';
+const playlist = '6NFODPrTH7nLylJS78DDlF';
+const url = `https://api.spotify.com/v1/users/${user}/playlists/${playlist}`
+const headers = {
+    'Accept': 'application/json',
+    'Content-Type': 'application/json',
+    'Authorization': 'Bearer BQALYD-FMpB3OQLQcJ-syCnEuT9-uHhjTxZvwBpSsRszFuiiiQNIZWF06BHuEvT7BxG-bBUddQLv-SEW6RAcVOASDEs0OrdhD8BXQrBLoY-3Sy-onrliEfy_qOyBbLaOBFb9M2CY7wma0IppXh26C7ZB2e95RKQ'
+}
+
+const main = async () => {
+    const response = JSON.parse(await request({ url, headers }))
+    const songs = response.tracks.items.map(item => ({
+        name: item.track.name,
+        artists: item.track.artists.map(artist => artist.name)
+    }))
+    console.log(songs.map(song => `${song.artists}: ${song.name}`).reduce((prev, curr) => `${prev}\n${curr}`))
+}
+
+main()

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -112,7 +112,7 @@ export const reportRecap = (_users) => {
 
 export const reportStartWeek = (_users) => {
     const report = new Report()
-    report.reportOptions.week = settings.week
+    report.reportOptions.week = settings.week + 1
     report.reportOptions.startWeek = new Date(2018, 0, (report.reportOptions.week - 1) * 7)
     report.reportOptions.endWeek = new Date(2018, 0, (report.reportOptions.week) * 7 - 1)
     report.users = _users.filter(user => user.username != 'nowplaying-music')

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,7 +3,7 @@ export const settings = {
     username: process.env.STEEM_USERNAME,
     password: process.env.STEEM_PASSWORD,
     week: Math.ceil(((((new Date() as any) - (new Date(2018, 0, 1) as any)) / 86400000) ) / 7),
-    payout: 0.580,
+    payout: 8.001,
     tags: ['nowplaying', 'music', 'contest', 'share', 'spotify'],
     blacklist: [
         'arsaljr',


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9692067/37379875-2e595e7a-270c-11e8-93f0-38adcbbecba1.png)
### New Features
#### Spotify Integration
The spotify integration connects to a spotify account and keeps track of relevant playlists.  In this case it looks at all playlist with `#nowplaying' in the title.  The tracks are kept track of in the database under a `tracks` table which allows for some interesting new possibilities.  Playlists can be created and manipulated - allowing users to filter the global playlist by certain properties.  For example someone may only want to see tracks from people she follows or pre-approved.  DJ's can curate the nowplaying playlist with user-requested tracks.  It also allows for statistics - we can see the most popular artists, songs, genres.

#### Tracks
The `Track` class is based off of spotify's definition of a track.
```
class Track = {
  spotify_id: string;
  name: string;
  week: number;
  artists: string[];
  print()
  toString()
}
```
A playlist is made up of tracks
```
export class Playlist {
    id: string;
    name: string;
    week: number;
    tracks: Track[];
}
```
The spotify class has a getPlaylists function that returns fully populated playlists.  In future pull requests these playlists may be manipulated and rearranged.  The `reporter` will grab the spotify urls directly from spotify, instead of relying on a human to get the link.

### Now Playing
Check out the #nowplaying community and bot in action [here](https://steemit.com/nowplaying/@nowplaying-music/now-playing-week-11)
![](https://steemit-production-imageproxy-upload.s3.amazonaws.com/DQmSWxfGJgRD6XR7grLHWAEvM35ZmoPzNfQ3YAr6eVjhBvd)

