### PR TITLE
Spotify auth and replies

### DIFF
--- a/src/blockchainAPI/steemAPI.ts
+++ b/src/blockchainAPI/steemAPI.ts
@@ -25,7 +25,8 @@ export class SteemAPI {
                             did_comment: false,
                             did_vote: false,
                             is_approved: false,
-                            children: post.children
+                            children: post.children,
+                            read_replies: true,
                         }) as Post)
                     )
                 }
@@ -66,9 +67,7 @@ export class SteemAPI {
             })
         })
     }
-<<<<<<< HEAD
-}
-=======
+
 
     getReplies(post: Post): Promise<any> {
         return new Promise((resolve, reject) => {
@@ -92,9 +91,8 @@ export class SteemAPI {
                 if (err) {
                     reject({ err })
                 }
-                
+                resolve(response)
             })
         })
     }
 }
->>>>>>> 147ce8aa9bdb486e6e6ec6b4bc820752eb03c1f6

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -56,6 +56,7 @@ export class Bot {
             const allPosts = await this._blockchainAPI.getPosts(this.communityName)
             const results = await this._database.writePosts(allPosts)
             console.log(`- created: ${results.created}\n- updated: ${results.updated}`)
+            await this.replies()
             await this.approve()
             await this.comment()
             await this.vote()
@@ -84,7 +85,7 @@ export class Bot {
     async comment(): Promise<any> {
         try {
             const allPosts = await this._database.getPosts()
-            // Comment regardless of approved
+            
             const toCommentPosts = allPosts.filter(post => !post.did_comment && post.is_approved)
             console.log('- commenting on', toCommentPosts)
 
@@ -95,7 +96,7 @@ export class Bot {
                         await this._broadcaster.makeComment(post)
                         await this._database.writeComment(post)
                     } catch(e) {
-                        console.log('err commenting')
+                        console.log('err commenting', e)
                     }
                 }, index * 22 * 1000)
             })
@@ -204,48 +205,73 @@ export class Bot {
 
     async replies() {
         try {
-            const allPosts = await this._database.getPosts()
+            const spotify = Spotify.Instance()
+
+            const playlists = await spotify.getPlaylists()
+            const playlist = playlists.find(playlist => playlist.week === this.week)
+
+            const allPosts = (await this._database.getPosts())
+                .filter(post => post.read_replies)
             
-            // Only reply on approved posts
-            const toReplyPosts = allPosts.filter(post => !post.did_vote && post.is_approved)
-            // console.log('- replying to', toReplyPosts);
+            // find a post to reply on
+            allPosts.forEach(async rootPost => {
+                console.log('looking at', rootPost.author)
+                let replies: Post[] = await this._blockchainAPI.getReplies(rootPost)
+                const questionReply = replies.find(reply => reply.author === this.username)
+                
+                if (questionReply && questionReply.children) {
+                    console.log('reading', questionReply.author)
+                    // Read the replies
+                    replies = await this._blockchainAPI.getReplies(questionReply as Post)
+                    replies
+                    // Get responses from the author
+                    .filter((post: Post) => post.author === rootPost.author)
+                    .forEach(async (post: Post) => {
+                        try {
+                            // Check if we already commented on this one
+                            const subreplies = await this._blockchainAPI.getReplies(post)
+                            if (subreplies.find((reply: Post) => reply.author === this.username)) {
+                                // we already commented here
+                                console.log('already commented on you')
+                                return null
+                            } else {
+                                // Parse the comment
+                                const artistName = post.body.split('\n')[0]
+                                const trackName = post.body.split('\n')[1]
+                                console.log(artistName)
+                                console.log(trackName)
+                                // Only two lines
+                                if (post.body.split('\n').length === 2) {
+                                    // Search the track
+                                    try {
+                                        const track = await spotify.trackSearch(artistName, trackName)
+                                        track.postId = rootPost.id
+                                        try {
+                                            // make the reply
+                                            await this._broadcaster.makeReply(post, `Adding ${track.name} to the weekly playlist\n[![](${track.img})](${playlist.getLink()})`)
+                                            console.log('Posted a reply')
 
-            const post = toReplyPosts[0];
-            let replies = await this._blockchainAPI.getReplies(post)
-            const questionReply = replies.find(reply => reply.author === this.username)
-            if (questionReply.children) {
-                // Read the replies
-                replies = await this._blockchainAPI.getReplies(questionReply as Post)
-                if (replies.length) {
-                    const response = replies[0]
-                    
-                    const artistName = response.body.split('\n')[0]
-                    const trackName = response.body.split('\n')[1]
-                    
-                    // search for the track
-                    const spotify = Spotify.Instance()
-                    const track = await spotify.trackSearch(artistName, trackName)
-                    console.log(track)
+                                            // add to the database
+                                            await this._database.writeTrack(track)
+                                            console.log('wrote to database')
 
-                    this._broadcaster.makeReply(response, `Adding ${track.name} to the weekly playlist [![](${track.img})](${track.getLink()})`)
-
-                    // this._broadcaster.makeComment(replyPost)
+                                            // add to the playlist
+                                            await spotify.addTrack(playlist, track)
+                                            console.log('added ', track.name)
+                                        } catch (e) {
+                                            console.warn('Problem posting a reply', e)
+                                        }
+                                    } catch (e) {
+                                        console.warn('Problem finding the track', e)
+                                    }
+                                }
+                            }
+                        } catch(e) {
+                            console.warn('Error parsing post', e)
+                        }
+                    })
                 }
-            } else {
-            }
-
-            
-            // Reply on each one with 25 second breaks
-            // toReplyPosts.forEach((post, index) => {
-            //     setTimeout(async () => {
-            //         try {
-            //             await this._broadcaster.makeVote(post)
-            //             await this._database.writeVote(post)
-            //         } catch(e) {
-            //             console.log('err voting')
-            //         }
-            //     }, index * 25 * 1000)
-            // })
+            })
         } catch(e) {
             console.log('something went wrong', e)
         } 

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -56,10 +56,10 @@ export class Bot {
             const allPosts = await this._blockchainAPI.getPosts(this.communityName)
             const results = await this._database.writePosts(allPosts)
             console.log(`- created: ${results.created}\n- updated: ${results.updated}`)
-            await this.replies()
             await this.approve()
             await this.comment()
             await this.vote()
+            await this.replies()
             
         } catch(e) {
             console.log(e)
@@ -272,6 +272,7 @@ export class Bot {
                         }
                     })
                 }
+                return true
             })
         } catch(e) {
             console.log('something went wrong', e)

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -206,11 +206,11 @@ export class Bot {
     async replies() {
         try {
             const spotify = Spotify.Instance()
-            await spotify.authenticate()
-            return
+            const tokens = await spotify.authenticate()
+            
             const playlists = await spotify.getPlaylists()
             const playlist = playlists.find(playlist => playlist.week === this.week)
-
+            
             const allPosts = (await this._database.getPosts())
                 .filter(post => post.read_replies)
             

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -206,7 +206,8 @@ export class Bot {
     async replies() {
         try {
             const spotify = Spotify.Instance()
-
+            await spotify.authenticate()
+            return
             const playlists = await spotify.getPlaylists()
             const playlist = playlists.find(playlist => playlist.week === this.week)
 

--- a/src/broadcaster/steemBroadcaster.ts
+++ b/src/broadcaster/steemBroadcaster.ts
@@ -1,4 +1,5 @@
 import { Post } from '../classes/post';
+import { settings } from '../settings';
 
 const steem = require('steem')
 export class SteemBroadcaster {
@@ -7,67 +8,79 @@ export class SteemBroadcaster {
     private _postingWif: string;
     private _debug: boolean;
 
+    private handleVoteError(error: any) {
+        return new Promise((_, reject) => {
+            if (error.code === -32000) {
+                console.log('think i have already voted')
+                reject({ markVoted: true })
+            } else if (error.data.code === 10) {
+                if (this._debug) {
+                    console.log(0);
+                }
+                if (error.data.stack[0].format.includes('STEEMIT_VOTE_DUST_THRESHOLD')) {
+                    // Vote too small
+                    console.log(this._voteErrs[1])
+                    reject(1)
+                } else if (error.data.stack[0].format.includes('You have already voted in a similar way')) {
+                    // Already voted with this voting power
+                    if (this._debug) {
+                        console.log(this._voteErrs[2]);
+                    }
+                    reject(2)
+                } else if (error.data.stack[0].format.includes('STEEMIT_MIN_VOTE_INTERVAL_SEC')) {
+                    // Only vote every 3 seconds
+                    if (this._debug) {
+                        console.log(this._voteErrs[3]);
+                    }
+                    // resolve in 3 seconds to vote again
+                    setTimeout(() => reject({ retry: true }), 3000)
+                } else if (error.data.stack[0].format.includes('STEEMIT_MAX_VOTE_CHANGES')) {
+                    if (this._debug) {
+                        console.log(this._voteErrs[4]);
+                    }
+                    reject(4)
+                } else {
+                    if (this._debug) {
+                        console.log(error.data.stack[0].format);
+                    }
+                    reject(error)
+                }
+                if (this._debug) {
+                    console.log(-1);
+                }
+            } else {
+                if (this._debug) {
+                    console.log(-2);
+                }
+            }
+        })
+    }
+        
     setCredentials(username: string, postingWif: string): void {
         this._username = username;
         this._postingWif = postingWif;
     }
 
     makeVote(post: Post, votingPower: number = 100): Promise<any> {
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve) => {
             steem.broadcast.vote(this._postingWif, this._username, post.author, post.permlink, votingPower * 100, (error, result) => {
-	    	try {
-                if (error) {
-                    let err = error
-                    if (error.payload.error.data.code) {
-                        err = error.payload.error
-                    }
-                    if (err.data.code === 10) {
-                        if (this._debug) {
-                            console.log(0);
-                        }
-                        if (err.data.stack[0].format.includes('STEEMIT_VOTE_DUST_THRESHOLD')) {
-                            // Vote too small
-                            console.log(this._voteErrs[1])
-                            reject(1)
-                        } else if (err.data.stack[0].format.includes('You have already voted in a similar way')) {
-                            // Already voted with this voting power
-                            if (this._debug) {
-                                console.log(this._voteErrs[2]);
+                try {
+                    if (error) {
+                        this.handleVoteError(error)
+                        .catch(async errObj => {
+                            if (errObj.retry) {
+                                return await this.makeVote(post, votingPower)
+                            } else if (errObj.markVoted) {
+                                resolve(errObj)
                             }
-                            reject(2)
-                        } else if (err.data.stack[0].format.includes('STEEMIT_MIN_VOTE_INTERVAL_SEC')) {
-                            // Only vote every 3 seconds
-                            if (this._debug) {
-                                console.log(this._voteErrs[3]);
-                            }
-                            console.log('trying again in 3 seconds')
-                            setTimeout(() => this.makeVote(post, votingPower), 3000)
-                        } else if (err.data.stack[0].format.includes('STEEMIT_MAX_VOTE_CHANGES')) {
-                            if (this._debug) {
-                                console.log(this._voteErrs[4]);
-                            }
-                            reject(4)
-                        } else {
-                            if (this._debug) {
-                                console.log(err.data.stack[0].format);
-                            }
-                            reject(err)
-                        }
-                        if (this._debug) {
-                            console.log(-1);
-                        }
+                        })
                     } else {
-                        if (this._debug) {
-                            console.log(-2);
-                        }
+                        console.log('successfully voted for ', post.author)
+                        resolve(result)
                     }
-                } else {
-                    console.log('successfully voted for ', post.author)
-                    resolve(result)
+                } catch(e) {
+                    console.log('hit some err', e)
                 }
-		} catch(e) {
-			console.log('hit some err', e)
-		}
             })
         })
     }
@@ -75,8 +88,10 @@ export class SteemBroadcaster {
     makeComment(post: Post): Promise<any> {
         return new Promise(async (resolve, reject) => {
             console.log('commenting on ', post.author, post.permlink)
-            const commentBody = `Thanks for entering this week's #nowplaying!`
-            steem.broadcast.comment(this._postingWif, post.author, post.permlink, this._username, `nowplaying-${new Date().getTime()}`, '', commentBody, { tags: ['nowplaying', 'music'], app: `nowplaying`}, (err, result) => {
+            const commentBody = settings.commentBody
+            const permlink = `nowplaying-${new Date().getTime()}`
+            console.log(permlink.replace(/\W+/g, ""))
+            steem.broadcast.comment(this._postingWif, post.author, post.permlink, this._username, permlink, '', commentBody, { tags: ['nowplaying', 'music'], app: `nowplaying`}, (err, result) => {
                 if (err) {
                     try {
                         if (err.data.code == 10) {
@@ -105,8 +120,10 @@ export class SteemBroadcaster {
             steem.broadcast.comment(this._postingWif, post.author, post.permlink, this._username, `re-${post.permlink}`, '', body, { tags: ['nowplaying']}, (err, result) => {
                 if (err) {
                     console.log('encountered an error replying')
+                    reject({ err })
                 } else {
                     console.log('successfully replied')
+                    resolve(result)
                 }
             })
         })
@@ -126,4 +143,3 @@ export class SteemBroadcaster {
         })
     }
 }
-

--- a/src/classes/playlist.ts
+++ b/src/classes/playlist.ts
@@ -1,8 +1,14 @@
+import { settings } from './../settings'
 import { Track } from './track'
 
 export class Playlist {
+    spotify_id: string;
     id: string;
     name: string;
     week: number;
     tracks: Track[];
+
+    public getLink() {
+        return `https://open.spotify.com/user/${settings.spotifyUserId}/playlist/${this.spotify_id}`
+    }
 }

--- a/src/classes/post.ts
+++ b/src/classes/post.ts
@@ -1,5 +1,6 @@
 import { JsonMetadata } from './jsonMetadata'
 export class Post {
+    id: number;
     
     // STEEM
     author: string;
@@ -12,6 +13,7 @@ export class Post {
     votes: number;
     active_votes: { voter: string }[];
     children: number;
+    read_replies: boolean;
     
     // SQL
     did_comment: boolean;

--- a/src/classes/track.ts
+++ b/src/classes/track.ts
@@ -4,6 +4,7 @@ export class Track {
     week: number;
     artists: string[];
     img: string;
+    postId: number;
 
     public getLink() {
         return `https://open.spotify.com/track/${this.spotify_id}`

--- a/src/database/sqlDatabase.ts
+++ b/src/database/sqlDatabase.ts
@@ -48,6 +48,7 @@ export class sqlDatabase {
     async getPosts(): Promise < Post[] > {
         const posts: Array < any > = await this._con.query('SELECT * FROM posts');
         return posts.map(d => ({
+            id: d.id,
             author: d.author,
             permlink: d.permlink,
             tag: d.tag,
@@ -56,7 +57,8 @@ export class sqlDatabase {
             did_comment: d.did_comment,
             did_vote: d.did_vote,
             is_approved: d.is_approved,
-            children: d.children
+            children: d.children,
+            read_replies: d.read_replies
         }) as Post)
         .filter(post => !settings.blacklist.includes(post.author))
     }
@@ -117,7 +119,6 @@ export class sqlDatabase {
 
     async writeTrack(track: Track): Promise<any> {
         const result = await this._con.query('INSERT INTO tracks SET ?', [track])
-        console.log(result)
         return result
     }
 }

--- a/src/process/spotify.ts
+++ b/src/process/spotify.ts
@@ -1,11 +1,15 @@
 const request = require('request-promise-native')
 import { Playlist } from '../classes/playlist'
 import { Track } from '../classes/track';
+import { settings } from '../settings';
 
 export class Spotify {
     private static spotify: Spotify = null;
+    private access_token: string = process.env.ACCESS_TOKEN;
+    private refresh_token: string = process.env.SPOTIFY_REFRESH_TOKEN;
     private _user: string = '1240132288'
     private _urls = {
+        auth: () => `https://accounts.spotify.com/api/token`,
         tracks: (userId, playlistId) => `https://api.spotify.com/v1/users/${userId}/playlists/${playlistId}/tracks`,
         playlists: (userId, playlistId?: number) => `https://api.spotify.com/v1/users/${userId}/playlists/?limit=50`,
         search: (track, artist) => `https://api.spotify.com/v1/search?q=${encodeURIComponent(track)}%20${encodeURIComponent(artist)}&type=track`,
@@ -14,7 +18,6 @@ export class Spotify {
     private _headers = {
         'Accept': 'application/json',
         'Content-Type': 'application/json',
-        'Authorization': settings.bearer,
     }
 
     private constructor() { }
@@ -29,10 +32,78 @@ export class Spotify {
         // return the singleton object
         return this.spotify
     }
+
+    private refresh_authentication = async () => {
+        try {
+            const response = JSON.parse(
+                await request.post({
+                    url: this._urls.auth(),
+                    headers: {
+                        'content-type': 'application/x-www-form-urlencoded'
+                    }
+                }).form({
+                    grant_type: 'refresh_token',
+                    refresh_token: this.refresh_token,
+                    client_id: process.env.SPOTIFY_CLIENT_ID,
+                    client_secret: process.env.SPOTIFY_CLIENT_SECRET,
+                })
+            )
+            console.log('~refreshed~')
+            this.access_token = response.access_token
+            return true
+        } catch(e) {
+            console.warn('error refreshing', e)
+            throw e
+        }
+    }
+
+    public authenticate = async () => {
+        try {
+            if (!this.refresh_token) {
+                const response = JSON.parse(
+                    await request.post({
+                        url: this._urls.auth(),
+                        headers: {
+                            'content-type': 'application/x-www-form-urlencoded'
+                        }
+                    }).form({
+                        grant_type: 'authorization_code',
+                        code: process.env.SPOTIFY_AUTH,
+                        redirect_uri: 'https://www.google.com',
+                        client_id: process.env.SPOTIFY_CLIENT_ID,
+                        client_secret: process.env.SPOTIFY_CLIENT_SECRET,
+                    })
+                )
+                console.log('~authenticated~')
+                this.access_token = response.access_token;
+                this.refresh_token = response.refresh_token;
+                setInterval(this.refresh_authentication, response.expires_in * 1000)
+            }
+            await new Promise(resolve => setTimeout(resolve, 1000))
+            this.refresh_authentication()
+            return true
+        } catch(e) {
+            if (e.error) {
+                const error = JSON.parse(e.error)
+                if (error.error_description === 'Authorization code expired') {
+                    console.warn('Authoarization __ code __ expired doofus')
+                } else {
+                    console.warn('~~error1~~', error)
+                }
+            } else {
+                console.warn('didnt go well', e)
+            }
+        }
+    }
     
     public addTrack = async (playlist: Playlist, track: Track) => {
         try {
-            const response = JSON.parse(await request.post({ url: this._urls.addTrack(this._user, playlist.spotify_id, track.spotify_id), headers: this._headers }))
+            const response = JSON.parse(
+                await request.post({
+                    url: this._urls.addTrack(this._user, playlist.spotify_id, track.spotify_id),
+                    headers: this._headers
+                })
+            )
             return response
         } catch (e) {
             console.log(e)

--- a/src/process/spotify.ts
+++ b/src/process/spotify.ts
@@ -8,12 +8,13 @@ export class Spotify {
     private _urls = {
         tracks: (userId, playlistId) => `https://api.spotify.com/v1/users/${userId}/playlists/${playlistId}/tracks`,
         playlists: (userId, playlistId?: number) => `https://api.spotify.com/v1/users/${userId}/playlists/?limit=50`,
-        search: (track, artist) => `https://api.spotify.com/v1/search?q=${encodeURIComponent(track)}%20${encodeURIComponent(artist)}&type=track`
+        search: (track, artist) => `https://api.spotify.com/v1/search?q=${encodeURIComponent(track)}%20${encodeURIComponent(artist)}&type=track`,
+        addTrack: (userId, playlistId, trackId) => `https://api.spotify.com/v1/users/${userId}/playlists/${playlistId}/tracks?uris=${encodeURIComponent(`spotify:track:${trackId}`)}`
     }
     private _headers = {
         'Accept': 'application/json',
         'Content-Type': 'application/json',
-        'Authorization': 'Bearer BQDw3hCQMubI01BP0VhSxYXN-K9upGmHdY_ioGC2IDKh6NiHq9mH8hB8Q4XxWyrPU8nef82lHXHYW8MryRa7_rKB-38mEAqyYkxoehp6ZbjWpc1CEJWtghrXuJZsnf7xqpsOwSGsglKtlFaq8A5PgqGc4x0JFzU'
+        'Authorization': settings.bearer,
     }
 
     private constructor() { }
@@ -27,24 +28,38 @@ export class Spotify {
         }
         // return the singleton object
         return this.spotify
+    }
+    
+    public addTrack = async (playlist: Playlist, track: Track) => {
+        try {
+            const response = JSON.parse(await request.post({ url: this._urls.addTrack(this._user, playlist.spotify_id, track.spotify_id), headers: this._headers }))
+            return response
+        } catch (e) {
+            console.log(e)
+            console.log('Error adding track')
         }
+    }
 
     /**
      * This function will mutate the playlist param and populate with tracks
      * @param playlist gets the tracks for a playlist
      */
     private getTracks = async (playlist: Playlist) => {
-        const response = JSON.parse(await request({ url: this._urls.tracks(this._user, playlist.id), headers: this._headers }))
-        playlist.tracks = response.items
-            .map(item => item.track)
-            .map(item => ({
-                spotify_id: item.id,
-                name: item.name,
-                artists: item.artists.map(a => a.name),
-                week: playlist.week
-            }))
-        
-        return playlist
+        try {
+            const response = JSON.parse(await request({ url: this._urls.tracks(this._user, playlist.id), headers: this._headers }))
+            playlist.tracks = response.items
+                .map(item => item.track)
+                .map(item => ({
+                    spotify_id: item.id,
+                    name: item.name,
+                    artists: item.artists.map(a => a.name),
+                    week: playlist.week
+                }))
+                
+            return playlist
+        } catch(e) {
+            console.log(`couldn't get track`, e)
+        }
         
     }
 
@@ -53,7 +68,13 @@ export class Spotify {
         const playlistPromises = response.items
             .filter(item => item.name.includes('#nowplaying'))
             .map(item => Object.assign({}, item, { week: parseInt(item.name.split('#nowplaying')[1]) }))
-            .map((item): Playlist => ({ id: item.id, name: item.name, week: item.week } as Playlist))
+            .map((item): Playlist => {
+                const playlist = new Playlist()
+                playlist.spotify_id = item.id;
+                playlist.name = item.name;
+                playlist.week = item.week
+                return playlist
+            })
             .map(playlist => this.getTracks(playlist)) as Promise<Playlist>[]
         const playlists = await Promise.all(playlistPromises)
 
@@ -61,22 +82,27 @@ export class Spotify {
     }
 
     public trackSearch = async (trackName: string, artistName: string) => {
-        const response = JSON.parse(await request({ url: this._urls.search(trackName, artistName), headers: this._headers }))
+        try {
+            const response = JSON.parse(await request({ url: this._urls.search(trackName, artistName), headers: this._headers }))
 
-        const song = response.tracks.items[0]
-        const track = new Track()
+            const song = response.tracks.items[0]
+            const track = new Track()
 
-        track.spotify_id = song.id;
-        track.name = song.name;
-        track.artists = song.artists.map(artist => artist.name);
-        track.img = song.album.images[0].url
-        return track
+            track.spotify_id = song.id;
+            track.name = song.name;
+            track.artists = song.artists.map(artist => artist.name);
+            track.img = song.album.images[0].url
+            return track
+        } catch(e) {
+            console.warn('error searching for track', trackName, artistName, this._urls.search(trackName, artistName), e)
+            throw e
+        }
     }
 
     public test = async () => {
         const playlists = (await this.getPlaylists()).map(playlist => {
             const ret = new Playlist()
-            ret.id = playlist.id,
+            ret.spotify_id = playlist.spotify_id,
             ret.name = playlist.name,
             ret.tracks = playlist.tracks.map(track => {
                 const trackRet = new Track()

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -25,4 +25,7 @@ export const settings = {
     // Spotify
     spotifyLink: 'https://open.spotify.com/user/1240132288/playlist/0zOxW1tvzXkNUXtlfMIV5C?si=gFlNl8WxRX6Tsc8QF-ffAw',
     spotifyImg: 'https://steemitimages.com/DQmXpCkcSg6oZE9ucEiQHvAFJmQj2iWzidGjrHWYpKMDVnb/image.png',
+    spotifyUserId: 1240132288,
+
+    commentBody: `Thanks for entering this week's #nowplaying!\nIf you would like your song added to the weekly spotify playlist, reply to this comment in the following format:\n\`\`\`\nArtist\nSong\n\`\`\`\nIf you have multiple songs, make multiple replies to this comment`
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -27,5 +27,7 @@ export const settings = {
     spotifyImg: 'https://steemitimages.com/DQmXpCkcSg6oZE9ucEiQHvAFJmQj2iWzidGjrHWYpKMDVnb/image.png',
     spotifyUserId: 1240132288,
 
-    commentBody: `Thanks for entering this week's #nowplaying!\nIf you would like your song added to the weekly spotify playlist, reply to this comment in the following format:\n\`\`\`\nArtist\nSong\n\`\`\`\nIf you have multiple songs, make multiple replies to this comment`
+    commentBody: `Thanks for entering this week's #nowplaying!\nIf you would like your song added to the weekly spotify playlist, reply to this comment in the following format:\n\`\`\`\nArtist\nSong\n\`\`\`\nIf you have multiple songs, make multiple replies to this comment`,
+    access_token: null,
+    refresh_token: null,
 }


### PR DESCRIPTION
### New Features
#### Spotify Authentication
This PR finally implements the entire spotify oauth process using the [Authorization Code](https://beta.developer.spotify.com/documentation/general/guides/authorization-guide/#authorization-code-flow) method.  It requires that you set three environment variables
```
export SPOTIFY_AUTH={{your spotify authorization code}}
export SPOTIFY_CLIENT_ID={{your spotify client id}}
export SPOTIFY_CLIENT_SECRET={{your spotify client secret}}
```
The processes uses these variables in a request sent to spotify which returns an `access_token` and a `refresh_token`.  The `access_token` is used on subsequent requests to get information from the spotify API, while the `refresh_token` is used after 60 minutes to generate a new `access_token`.

![image](https://user-images.githubusercontent.com/9692067/38006307-73850f06-3212-11e8-9959-79ef03a522ad.png)

Once we have access to spotify, we can search for songs and manipulate playlists.  This lets us add songs directly to the weekly playlist, and keep track of who chooses what song.  Replies are parsed and used to search spotify's database for the track.  If found, the bot will reply and add that song to the weekly playlist, automating much of the process.

### Now Playing
Check out the #nowplaying community and bot in action [here](https://steemit.com/nowplaying/@nowplaying-music/nowplaying-week-13)
