### PR TITLE
Test cases reporter

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -9,6 +9,7 @@ branches:
 env:
   global:
     - TEST_RESULTS_DIR=$SHIPPABLE_REPO_DIR/shippable/testresults
+    - NOWPLAYING_TESTING=true
     - DB_USER=shippable
 
 services:

--- a/src/__tests__/reporter.spec.ts
+++ b/src/__tests__/reporter.spec.ts
@@ -1,0 +1,77 @@
+import { initializeReport, leaderboard, contestants, payout, spotify, getNumVotes } from "../reporter";
+import { User } from "../classes/user";
+import { settings } from "../settings";
+
+const users: User[] = [{
+    username: 'user1',
+    posts: [{
+        id: 3,
+        author: 'user1',
+        permlink: 'nowplaying-week-10',
+        created: new Date(2018, 0, 57).getTime(),
+        is_approved: true,
+        votes: 15
+    }]
+}]
+
+describe('Reporter Functions', () => {
+    it('getNumVotes', () => {
+        const x = getNumVotes(users[0].posts)
+        expect(x).toBe(15)
+
+    })
+})
+
+describe('Reporter Post Body', () => {
+    it('initializes a postweek report', () => {
+        const report = initializeReport(users, true)
+        
+        expect(report).toBeTruthy()
+        expect(settings.week).toBe(10)
+        expect(report.post.title).toBe(`Now Playing: Week 9 (Feb 25 - Mar 3)`)
+    })
+    
+    it('initializes a recap report', () => {
+        const report = initializeReport(users)
+        
+        expect(report).toBeTruthy()
+        expect(settings.week).toBe(10)
+        expect(report.post.title).toBe(`Spotify Playlist: Week 9 (Feb 25 - Mar 3)`)
+    })
+
+    it('runs leaderboard correctly', () => {
+        const report = initializeReport(users)
+        leaderboard(report)
+        expect(report.post.body).toBe(`
+## <center>Leaderboards</center>
+Rank | User | Weeks | Votes
+-|-|-|-
+1 | @user1 | 1 | 15`
+        )
+    })
+    
+    it('runs contestants correctly', () => {
+        const report = initializeReport(users)
+        contestants(report)
+        expect(report.post.body).toBe(`
+<center>[user1](steemit.com/nowplaying/@user1/nowplaying-week-10)!</center>`
+        )
+    })
+
+    it('runs payout correctly', () => {
+        const report = initializeReport(users)
+        payout(report)
+        expect(report.post.body).toBe(`
+<center>Week 9 Contestants</center>
+<center>We had a total payout of about ${settings.payout} STEEM, which will be powered up to all 1 contestants.  That's about 0.4 SP per person!</center>`)
+    })
+
+    it('runs spotify correctly', () => {
+        const report = initializeReport(users)
+        spotify(report)
+        expect(report.post.body).toBe(`
+## <center>[Spotify Playlist](${report.reportOptions.spotifyLink})</center>
+<center>[![](${report.reportOptions.spotifyImg})](${report.reportOptions.spotifyLink})</center>`
+        )
+    })
+});

--- a/src/process/__tests__/init.spec.ts
+++ b/src/process/__tests__/init.spec.ts
@@ -7,11 +7,7 @@ describe('Init Test', () => {
     it('creates a bot successfully', async () => {
         const bot = await init()
         expect(bot).toBeTruthy
-        expect(bot.users.length).toBeTruthy
+        expect(bot.users).toBeTruthy
         bot.close()
-    })
-
-    afterAll(async () => {
-        console.log('after everything')
     })
 });

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -5,8 +5,9 @@ import { weekFilter } from './filters';
 const dateformat = require('dateformat')
 import { Report } from './classes/report'
 import { settings } from './settings';
+import { User } from './classes/user';
 
-const getNumWeeks = (posts: Post[]): number => posts
+export const getNumWeeks = (posts: Post[]): number => posts
     // Map each post to its week #
     .map(post => getWeek(new Date(post.created)))
     // Remove duplicates
@@ -14,9 +15,9 @@ const getNumWeeks = (posts: Post[]): number => posts
     // Return number of weeks
     .length
 
-const getNumVotes = (posts: Post[]): number => posts.map(p => p.is_approved ? p.votes : 0).reduce((prev, curr) => prev + curr, 0)
+export const getNumVotes = (posts: Post[]): number => posts.map(p => p.is_approved ? p.votes : 0).reduce((prev, curr) => prev + curr, 0)
 
-const getRankings = (report: Report): string => report.users
+export const getRankings = (report: Report): string => report.users
     .map(user => ({
         username: `@${user.username}`,
         weeks: getNumWeeks(user.posts),
@@ -30,27 +31,27 @@ const getRankings = (report: Report): string => report.users
 // export const playerStats = (users: User[], username: string) => getRankings({ users, reportOptions: { week: 5}} as Report).find(x => x.author === username).text
     // getRankings({users, reportOptions: {week: 5}} as Report).find(str => str.includes(`@${username}`))
 
-const center = (str: string) => `<center>${str}</center>`
+export const center = (str: string) => `<center>${str}</center>`
 
-const startTitle = (report: Report): Report => {
+export const startTitle = (report: Report): Report => {
     report.post.body = `${report.post.body}# ${center(`Now Playing: Week ${report.reportOptions.week} (${dateformat(report.reportOptions.startWeek, 'mmm d')} - ${dateformat(report.reportOptions.endWeek, 'mmm d')})`)}`
     return report
 }
-const endTitle = (report: Report): Report => {
+export const endTitle = (report: Report): Report => {
     report.post.body = `${report.post.body}# ${center(`Now Playing Recap: Week ${report.reportOptions.week} (${dateformat(report.reportOptions.startWeek, 'mmm d')} - ${dateformat(report.reportOptions.endWeek, 'mmm d')})`)}`
     return report
 }
 
-const subtitle = (report: Report): Report => {
+export const subtitle = (report: Report): Report => {
     report.post.body = `${report.post.body}\n${center(`\`Now Playing\` is a way to share what you're listening to this week with others.`)}`
     return report
 }
-const logo = (report: Report): Report => {
+export const logo = (report: Report): Report => {
     report.post.body = `${report.post.body}\n![](https://steemitimages.com/DQmeUqpd5RJbEUEkdTHqYBZYmcA137fUq4FX5nTN6yBuscW/image.png)`
     return report
 }
 
-const rules = (report: Report): Report => {
+export const rules = (report: Report): Report => {
     report.post.body = `${report.post.body}\n## <center>Steemit Now Playing Rules</center>
 
 | Week ${report.reportOptions.week} spans from Sun. ${dateformat(report.reportOptions.startWeek, 'mmm d')} to Sat. ${dateformat(report.reportOptions.endWeek, 'mmm d')}
@@ -68,30 +69,29 @@ const rules = (report: Report): Report => {
     return report
 }
 
-const spotify = (report: Report): Report => {
+export const spotify = (report: Report): Report => {
     report.post.body = `${report.post.body}\n## ${center(`[Spotify Playlist](${report.reportOptions.spotifyLink})`)}\n${center(`[![](${report.reportOptions.spotifyImg})](${report.reportOptions.spotifyLink})`)}`
     return report
 }
 
-const payout = (report: Report): Report => {
+export const payout = (report: Report): Report => {
     const users = report.users.filter(weekFilter(settings.week - 1))
-    report.post.body = `${report.post.body}\n ${center(`Week ${report.reportOptions.week} Contestants`)}\n${center(`We had a total payout of about ${report.reportOptions.payout} STEEM, which will be powered up to all ${users.length} contestants.  That's about ${parseInt(String(report.reportOptions.payout / users.length * 1000)) / 1000} SP per person!`)}`
+    report.post.body = `${report.post.body}\n${center(`Week ${report.reportOptions.week} Contestants`)}\n${center(`We had a total payout of about ${report.reportOptions.payout} STEEM, which will be powered up to all ${users.length} contestants.  That's about ${parseInt(String(report.reportOptions.payout / users.length * 1000)) / 1000} SP per person!`)}`
     return report
 }
 
-const contestants = (report: Report): Report => {
+export const contestants = (report: Report): Report => {
     const users = report.users.filter(weekFilter(settings.week - 1))
     report.post.body = `${report.post.body}\n${center(`${users.reduce((str, user, index) => `${str}[${user.username}](steemit.com/nowplaying/@${user.username}/${user.posts[user.posts.length - 1].permlink})${index === users.length-1 ? '!' : ', '}`, '')}`)}`
     return report
 }
 
-const leaderboard = (report: Report): Report => {
-    report.post.body = `${report.post.body}\n## ${center(`Leaderboards`)}\nRank | User | Weeks | Votes\n-|-|-|-\n${getRankings(report)}`
+export const leaderboard = (report: Report): Report => {
+    report.post.body = `${report.post.body}\n## ${center(`Leaderboards`)}\nRank | User | Weeks | Votes\n-|-|-|-${getRankings(report)}`
     return report
 }
 
-
-export const reportRecap = (_users) => {
+export const initializeReport = (users: User[], postWeek = false): Report => {
     const report = new Report()
     report.reportOptions.week = settings.week - 1
     report.reportOptions.startWeek = new Date(2018, 0, (report.reportOptions.week - 1) * 7)
@@ -99,29 +99,24 @@ export const reportRecap = (_users) => {
     report.reportOptions.payout = settings.payout
     report.reportOptions.spotifyLink = settings.spotifyLink
     report.reportOptions.spotifyImg = settings.spotifyImg
-
-    report.users = _users.filter(user => user.username != 'nowplaying-music')//.filter(weekFilter(report.reportOptions.week))
+    report.users = users.filter(user => user.username != 'nowplaying-music')//.filter(weekFilter(report.reportOptions.week))
     report.post.author = settings.username
+    report.post.permlink = `nowplaying-${postWeek ? '' : 'recap-'}week-${report.reportOptions.week}`
     report.post.body = ''
-    report.post.permlink = `nowplaying-recap-week-${report.reportOptions.week}`
     report.post.jsonMetadata.app = settings.communityName
     report.post.jsonMetadata.tags = settings.tags
-    report.post.title = `Spotify Playlist: Week ${report.reportOptions.week} (${dateformat(report.reportOptions.startWeek, 'mmm d')} - ${dateformat(report.reportOptions.endWeek, 'mmm d')})`
+    report.post.title = postWeek
+        ? `Now Playing: Week ${report.reportOptions.week} (${dateformat(report.reportOptions.startWeek, 'mmm d')} - ${dateformat(report.reportOptions.endWeek, 'mmm d')})`
+        : `Spotify Playlist: Week ${report.reportOptions.week} (${dateformat(report.reportOptions.startWeek, 'mmm d')} - ${dateformat(report.reportOptions.endWeek, 'mmm d')})`
+    return report
+}
+
+export const reportRecap = (_users) => {
+    const report = initializeReport(_users, false)
     return leaderboard(contestants(payout(spotify(subtitle(endTitle(report))))))
 }
 
 export const reportStartWeek = (_users) => {
-    const report = new Report()
-    report.reportOptions.week = settings.week + 1
-    report.reportOptions.startWeek = new Date(2018, 0, (report.reportOptions.week - 1) * 7)
-    report.reportOptions.endWeek = new Date(2018, 0, (report.reportOptions.week) * 7 - 1)
-    report.users = _users.filter(user => user.username != 'nowplaying-music')
-    report.post.author = settings.username
-    report.post.body = ''
-    report.post.permlink = `nowplaying-week-${report.reportOptions.week}`
-    report.post.jsonMetadata.app = settings.communityName
-    report.post.jsonMetadata.tags = settings.tags
-    report.post.title = `Now Playing: Week ${report.reportOptions.week} (${dateformat(report.reportOptions.startWeek, 'mmm d')} - ${dateformat(report.reportOptions.endWeek, 'mmm d')})`
-
+    const report = initializeReport(_users, true)
     return leaderboard(rules(logo(subtitle(startTitle(report)))))
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,8 +1,10 @@
+const isTest = Boolean(process.env.NOWPLAYING_TESTING)
+
 export const settings = {
     communityName: 'nowplaying',
     username: process.env.STEEM_USERNAME,
     password: process.env.STEEM_PASSWORD,
-    week: Math.ceil(((((new Date() as any) - (new Date(2018, 0, 1) as any)) / 86400000) ) / 7),
+    week: isTest ? 10 : Math.ceil(((((new Date() as any) - (new Date(2018, 0, 1) as any)) / 86400000) ) / 7),
     payout: 0.4,
     tags: ['nowplaying', 'music', 'contest', 'share', 'spotify'],
     blacklist: [


### PR DESCRIPTION
### New Features
#### Reporter Test Cases
This pull request is the first of many that will add test cases for different parts of the system.  The first part I chose to add tests for was the `reporter`.  This includes both the `postWeek` and `postRecap` functions.

One thing to note is that when testing the `week` will always be `10`.  This allows us to use static text in the test cases to compare against, rather than dynamic.  I think this will provide better results because in the case that the dynamic week is broken, it will be both broken in the tests and outside of the tests and therefore the tests may still pass and let broken code through.

Tests were added for the following functions: `initializeReport, leaderboard, contestants, payout, spotify, getNumVotes`.  More will come in the future, as will better test reporting both locally and in shippable.  Note that shippable does not capture the results of the tests nor does it get the code coverage.  These are both issues that need to be addressed.

![image](https://user-images.githubusercontent.com/9692067/38196064-e7805fce-364e-11e8-866c-d9711d50b826.png)

It should look more like:
![image](https://user-images.githubusercontent.com/9692067/38196080-f8727cf4-364e-11e8-840d-91be43f1ff5e.png)

A new function `initializeReport(users: User[], postWeek = false)` has been added to make it easier to create a new report.  There is an optional parameter `postWeek` which defaults to false.  Use it like this:
```
const postRecap = initializeReport(users) OR initializeReport(users, false)
const postWeek = initializeReport(users, true)
```

The output of the current tests when running `jest` should look like this:
![image](https://user-images.githubusercontent.com/9692067/38196131-5007d3b0-364f-11e8-82c1-183c474bb171.png)

#### Nowplaying
Check out the #nowplaying community and bot in action [here](steemit.com/nowplaying/@nowplaying-music/nowplaying-week-10)

