### PR TITLE
Spotify stabilizing and error handling

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -64,7 +64,7 @@ export class Bot {
             await this.comment()
             await this.vote()
             await this.replies()
-            
+
         } catch(e) {
             console.log(e)
             console.log('got err')
@@ -89,7 +89,7 @@ export class Bot {
     async comment(): Promise<any> {
         try {
             const allPosts = await this._database.getPosts()
-            
+
             const toCommentPosts = allPosts.filter(post => !post.did_comment && post.is_approved)
             console.log('- commenting on', toCommentPosts)
 
@@ -211,20 +211,19 @@ export class Bot {
     async replies() {
         try {
             const spotify = Spotify.Instance()
-            const tokens = await spotify.authenticate()
-            
+            await spotify.authenticate()
+
             const playlists = await spotify.getPlaylists()
             const playlist = playlists.find(playlist => playlist.week === this.week)
-            
+
             const allPosts = (await this._database.getPosts())
                 .filter(post => post.read_replies)
-            
+
 
             for (const rootPost of allPosts) {
-                console.log(rootPost.author, rootPost.title)
                 let replies: Post[] = await this._blockchainAPI.getReplies(rootPost)
-             
-                // Find our reply asking for songs 
+
+                // Find our reply asking for songs
                 const questionReply = replies.find(reply => reply.author === this.username)
                 if (questionReply && questionReply.children) {
                     // Read the replies
@@ -244,7 +243,7 @@ export class Bot {
                                 // search the track
                                 const track = await spotify.trackSearch(artistName, trackName)
                                 track.postId = rootPost.id
-                                
+
                                 // make the reply
                                 await this._broadcaster.makeReply(post, `Adding ${track.name} to the weekly playlist\n[![](${track.img})](${playlist.getLink()})`)
                                 console.log('Posted a reply')
@@ -268,6 +267,6 @@ export class Bot {
             console.log('done with all posts')
         } catch(e) {
             console.log('something went wrong', e)
-        } 
+        }
     }
 }

--- a/src/process/spotify.ts
+++ b/src/process/spotify.ts
@@ -48,10 +48,7 @@ export class Spotify {
                     client_secret: process.env.SPOTIFY_CLIENT_SECRET,
                 })
             )
-            console.log('~refreshed~')
-            console.log(response)
             this.access_token = response.access_token
-            console.log('access:', this.access_token)
             return true
         } catch(e) {
             console.warn('error refreshing', e)
@@ -61,7 +58,6 @@ export class Spotify {
 
     public authenticate = async () => {
         const { SPOTIFY_AUTH, SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET } = process.env
-        console.log('authenticating...', SPOTIFY_AUTH, SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET)
         try {
             if (!this.refresh_token) {
                 const response = JSON.parse(
@@ -79,11 +75,8 @@ export class Spotify {
                     })
                 )
                 console.log('~authenticated~')
-                console.log(response)
                 this.access_token = response.access_token;
                 this.refresh_token = response.refresh_token;
-                console.log('access:', this.access_token)
-                console.log('refresh:', this.refresh_token)
             }
             setInterval(this.refresh_authentication, 3600 * 1000)
             return true
@@ -102,7 +95,7 @@ export class Spotify {
             }
         }
     }
-    
+
     public addTrack = async (playlist: Playlist, track: Track) => {
         try {
             const response = JSON.parse(
@@ -145,12 +138,12 @@ export class Spotify {
                     artists: item.artists.map(a => a.name),
                     week: playlist.week
                 }))
-                
+
             return playlist
         } catch(e) {
             console.log(`couldn't get track`, e)
         }
-        
+
     }
 
     public getPlaylists = async () => {
@@ -199,7 +192,7 @@ export class Spotify {
             if (response.tracks.items.length) {
                 const song = response.tracks.items[0]
                 const track = new Track()
-                
+
                 track.spotify_id = song.id;
                 track.name = song.name;
                 track.artists = song.artists.map(artist => artist.name);
@@ -244,7 +237,7 @@ export class Spotify {
             }, {})
             .sort((a, b) => a > b ? 1 : -1)
         console.log(songs)
-        
+
         const playlist_songs = playlists.map(playlist => playlist.tracks.map(track => track.toString()))
         console.log(playlist_songs)
     }

--- a/src/process/spotify.ts
+++ b/src/process/spotify.ts
@@ -60,6 +60,7 @@ export class Spotify {
     }
 
     public authenticate = async () => {
+        console.log('authenticating...', this.access_token, this.refresh_token, process.env.ACCESS_TOKEN)
         try {
             if (!this.refresh_token) {
                 const response = JSON.parse(
@@ -89,9 +90,11 @@ export class Spotify {
             if (e.error) {
                 const error = JSON.parse(e.error)
                 if (error.error_description === 'Authorization code expired') {
-                    console.warn('Authoarization __ code __ expired doofus')
+                    console.warn('Authorization __ code __ expired doofus')
+                } else if (error.error_description === 'Invalid access token') {
+                    console.warn('Invalid Access cokde', error)
                 } else {
-                    console.warn('~~error1~~', error)
+                    console.warn(error.error_description)
                 }
             } else {
                 console.warn('didnt go well', e)
@@ -192,15 +195,18 @@ export class Spotify {
                         'Authorization': `Bearer ${this.access_token}`,
                     }
                 }))
-
-            const song = response.tracks.items[0]
-            const track = new Track()
-
-            track.spotify_id = song.id;
-            track.name = song.name;
-            track.artists = song.artists.map(artist => artist.name);
-            track.img = song.album.images[0].url
-            return track
+            if (response.tracks.items.length) {
+                const song = response.tracks.items[0]
+                const track = new Track()
+                
+                track.spotify_id = song.id;
+                track.name = song.name;
+                track.artists = song.artists.map(artist => artist.name);
+                track.img = song.album.images[0].url
+                return track
+            } else {
+                throw { error: 'cant find', trackName, artistName }
+            }
         } catch(e) {
             console.warn('error searching for track', trackName, artistName, this._urls.search(trackName, artistName), e)
             throw e

--- a/src/process/spotify.ts
+++ b/src/process/spotify.ts
@@ -60,7 +60,8 @@ export class Spotify {
     }
 
     public authenticate = async () => {
-        console.log('authenticating...', this.access_token, this.refresh_token, process.env.ACCESS_TOKEN)
+        const { SPOTIFY_AUTH, SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET } = process.env
+        console.log('authenticating...', SPOTIFY_AUTH, SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET)
         try {
             if (!this.refresh_token) {
                 const response = JSON.parse(

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -93,7 +93,7 @@ export const leaderboard = (report: Report): Report => {
 
 export const initializeReport = (users: User[], postWeek = false): Report => {
     const report = new Report()
-    report.reportOptions.week = settings.week - 1
+    report.reportOptions.week = settings.week + 1
     report.reportOptions.startWeek = new Date(2018, 0, (report.reportOptions.week - 1) * 7)
     report.reportOptions.endWeek = new Date(2018, 0, (report.reportOptions.week) * 7 - 1)
     report.reportOptions.payout = settings.payout

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -93,7 +93,7 @@ export const leaderboard = (report: Report): Report => {
 
 export const initializeReport = (users: User[], postWeek = false): Report => {
     const report = new Report()
-    report.reportOptions.week = settings.week + 1
+    report.reportOptions.week = settings.week - 1
     report.reportOptions.startWeek = new Date(2018, 0, (report.reportOptions.week - 1) * 7)
     report.reportOptions.endWeek = new Date(2018, 0, (report.reportOptions.week) * 7 - 1)
     report.reportOptions.payout = settings.payout

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,7 +4,8 @@ export const settings = {
     communityName: 'nowplaying',
     username: process.env.STEEM_USERNAME,
     password: process.env.STEEM_PASSWORD,
-    week: isTest ? 10 : Math.ceil(((((new Date() as any) - (new Date(2018, 0, 1) as any)) / 86400000) ) / 7),
+    week: Math.ceil(((((new Date() as any) - (new Date(2018, 0, 1) as any)) / 86400000) ) / 7),
+    //week: isTest ? 10 : Math.ceil(((((new Date() as any) - (new Date(2018, 0, 1) as any)) / 86400000) ) / 7),
     payout: 0.4,
     tags: ['nowplaying', 'music', 'contest', 'share', 'spotify'],
     blacklist: [

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,8 +4,7 @@ export const settings = {
     communityName: 'nowplaying',
     username: process.env.STEEM_USERNAME,
     password: process.env.STEEM_PASSWORD,
-    week: Math.ceil(((((new Date() as any) - (new Date(2018, 0, 1) as any)) / 86400000) ) / 7),
-    //week: isTest ? 10 : Math.ceil(((((new Date() as any) - (new Date(2018, 0, 1) as any)) / 86400000) ) / 7),
+    week: isTest ? 10 : Math.ceil(((((new Date() as any) - (new Date(2018, 0, 1) as any)) / 86400000) ) / 7),
     payout: 0.4,
     tags: ['nowplaying', 'music', 'contest', 'share', 'spotify'],
     blacklist: [


### PR DESCRIPTION
### New Features
#### Waiting 20 seconds between posts
This pull request stabilizes and cleans up the code relating to the spotify-reply integration.  Rather than reading and processing all comments asynchronously, the code now runs through each reply synchronously and pauses 20 seconds between replies.

Before:
![image](https://user-images.githubusercontent.com/9692067/39397708-d5da8eba-4ad1-11e8-8030-6da7bec09e13.png)

After:
![image](https://user-images.githubusercontent.com/9692067/39397757-7b9a4a16-4ad2-11e8-8d8d-0eacc118258b.png)

#### Approaches
The simplest approach would be to delay each run by 20 seconds.  However, that means if we have 20 contestants it would take 20*20 = 2 minutes and 40 seconds to read the replies.  50 contestants would be 16 minutes and 40 seconds.  This approach does not scale well.

I could asynchornously loop through all replies and separate out the ones that nowplaying needs to respond to.  Then I could synchronously loop through the list and reply with a delay between each.  This takes 20 seconds per post we have to respond to, and we can't do any better than that with steem's limitations.

What I chose to do was a synchronous for loop
```
 for (const post of authorReplies) {
   await someFunction()
}
```
I have never experimented with the `for-of` loop before - it's very concise and easy to use.  It is comparable to `.forEach` except that it runs in sequence, meaning we can `return` or `break` or `continue`.  And if you throw an `await` in there, it will wait for it to resolve before continuing. 

### Next Steps
There is still more to be done regarding spotify replies.  Right now spotify supports an "artist search" and a "track search".  I have been using "track search" with `${artistName} ${trackName}` which gives pretty good results.  This needs to be smarter, and should probably use "track search" with `${trackName}` and then search the tracks for an artist name that's similar to `${artistName}`.

There is also a bit of a "bug" with the current week.  If I run the bot today and do not touch it, it will always think it's week 17.  This means that posts are approved if they upvoted week 17's post, not the current weeks post.  This became very obvious when one user missed a week that I ran the bot, and participated in the next two weeks.  Because she did not upvoted the post in which the bot was running, her posts were never getting approved even though she upvoted the next weekly posts.

### Now Playing
Check out the #nowplaying community and bot in action [here](https://steemit.com/nowplaying/@nowplaying-music/nowplaying-week-13)
