### PR TITLE
Weekly Automatic Posting

### DIFF
--- a/src/__tests__/reporter.spec.ts
+++ b/src/__tests__/reporter.spec.ts
@@ -27,7 +27,7 @@ describe('Reporter Post Body', () => {
         const report = initializeReport(users, true)
         
         expect(report).toBeTruthy()
-        expect(settings.week).toBe(10)
+        expect(settings.week()).toBe(10)
         expect(report.post.title).toBe(`Now Playing: Week 9 (Feb 25 - Mar 3)`)
     })
     
@@ -35,7 +35,7 @@ describe('Reporter Post Body', () => {
         const report = initializeReport(users)
         
         expect(report).toBeTruthy()
-        expect(settings.week).toBe(10)
+        expect(settings.week()).toBe(10)
         expect(report.post.title).toBe(`Spotify Playlist: Week 9 (Feb 25 - Mar 3)`)
     })
 

--- a/src/__tests__/reporter.spec.ts
+++ b/src/__tests__/reporter.spec.ts
@@ -25,15 +25,15 @@ describe('Reporter Functions', () => {
 describe('Reporter Post Body', () => {
     it('initializes a postweek report', () => {
         const report = initializeReport(users, true)
-        
+
         expect(report).toBeTruthy()
         expect(settings.week()).toBe(10)
         expect(report.post.title).toBe(`Now Playing: Week 9 (Feb 25 - Mar 3)`)
     })
-    
+
     it('initializes a recap report', () => {
         const report = initializeReport(users)
-        
+
         expect(report).toBeTruthy()
         expect(settings.week()).toBe(10)
         expect(report.post.title).toBe(`Spotify Playlist: Week 9 (Feb 25 - Mar 3)`)
@@ -44,12 +44,12 @@ describe('Reporter Post Body', () => {
         leaderboard(report)
         expect(report.post.body).toBe(`
 ## <center>Leaderboards</center>
-Rank | User | Weeks | Votes
+Rank | User | Weeks | Votes (per post)
 -|-|-|-
 1 | @user1 | 1 | 15`
         )
     })
-    
+
     it('runs contestants correctly', () => {
         const report = initializeReport(users)
         contestants(report)
@@ -63,7 +63,7 @@ Rank | User | Weeks | Votes
         payout(report)
         expect(report.post.body).toBe(`
 <center>Week 9 Contestants</center>
-<center>We had a total payout of about ${settings.payout} STEEM, which will be powered up to all 1 contestants.  That's about 0.4 SP per person!</center>`)
+<center>We had a total payout of about ${settings.payout} STEEM, which will be powered up to all 1 contestants.  That's about ${settings.payout} SP per person!</center>`)
     })
 
     it('runs spotify correctly', () => {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,6 +1,6 @@
 import { reportStartWeek, reportRecap } from './reporter';
 import { Broadcaster } from './broadcaster/broadcaster';
-import { Database } from './database/database'
+import { IDatabase } from './database/database'
 import { BlockchainAPI } from './blockchainAPI/blockchainAPI'
 import { User } from './classes/user';
 import { weekFilter } from './filters';
@@ -23,7 +23,7 @@ export class Bot {
 
     private _broadcaster: Broadcaster;
     private _blockchainAPI: BlockchainAPI;
-    private _database: Database;
+    private _database: IDatabase;
 
 
     getPostingWif(): string {
@@ -43,7 +43,7 @@ export class Bot {
         this._blockchainAPI = blockchainAPI
     }
 
-    async setDatabase(database: Database): Promise<void> {
+    async setDatabase(database: IDatabase): Promise<void> {
         this._database = database
         await this._database.setup()
         this.users = await this._database.getUsers()

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -55,7 +55,7 @@ export class Bot {
 
     async scrape(): Promise<any> {
         console.log(`[${dateformat(new Date(), 'mmmm dS, h:MM:ss TT')}]`)
-        console.log(`[Start Scraping]`)
+        console.log(`[Start Scraping - Week ${this.week}]`)
         try {
             const allPosts = await this._blockchainAPI.getPosts(this.communityName)
             const results = await this._database.writePosts(allPosts)

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -228,7 +228,7 @@ export class Bot {
                 if (questionReply && questionReply.children) {
                     // Read the replies
                     replies = await this._blockchainAPI.getReplies(questionReply as Post)
-                    const authorReplies = replies.filter((post: Post) => post.author === rootPost.author)
+                    const authorReplies = replies.filter((post: Post) => post.author === rootPost.author || post.author === this.username || post.author === 'walnut1')
                     for (const post of authorReplies) {
                         try {
                             // Check if we already commented on this one

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -25,7 +25,6 @@ export class Bot {
     private _blockchainAPI: BlockchainAPI;
     private _database: IDatabase;
 
-
     getPostingWif(): string {
         return steem.auth.toWif(this.username, this.password, 'posting')
     }
@@ -49,63 +48,65 @@ export class Bot {
         this.users = await this._database.getUsers()
     }
 
-    async close() {
-        await this._database.close()
+    public async close(): Promise<void> {
+        await this._database.close();
     }
 
-    async scrape(): Promise<any> {
-        console.log(`[${dateformat(new Date(), 'mmmm dS, h:MM:ss TT')}]`)
-        console.log(`[Start Scraping - Week ${this.week}]`)
+    public async scrape(): Promise<void> {
+        console.log(`[${dateformat(new Date(), 'mmmm dS, h:MM:ss TT')}]`);
+        console.log(`[Start Scraping - Week ${this.week}]`);
         try {
-            const allPosts = await this._blockchainAPI.getPosts(this.communityName)
-            const results = await this._database.writePosts(allPosts)
-            console.log(`- created: ${results.created}\n- updated: ${results.updated}`)
-            await this.approve()
-            await this.comment()
-            await this.vote()
-            await this.replies()
+            const allPosts = await this._blockchainAPI.getPosts(this.communityName);
+            const results = await this._database.writePosts(allPosts);
+            console.log(`- created: ${results.created}\n- updated: ${results.updated}`);
+            await this.approve();
+            await this.comment();
+            await this.vote();
+            await this.replies();
 
-        } catch(e) {
-            console.log(e)
-            console.log('got err')
+        } catch (e) {
+            console.log(e);
+            console.log('got err');
         }
-        console.log('[End Scraping]')
+        console.log('[End Scraping]');
     }
 
-    async approve(): Promise<any> {
-        const allPosts = await this._database.getPosts()
-        const unapproved = allPosts.filter(post => !post.is_approved)
+    public async approve(): Promise<void> {
+        const allPosts = await this._database.getPosts();
+        const unapproved = allPosts.filter((post: Post) => !post.is_approved);
 
-        const permlink = `${this.communityName}-week-${this.week}`
-        const weekPost = await this._blockchainAPI.getPost({ author: this.username, permlink } as Post)
-        const voters = weekPost.active_votes.map(vote => vote.voter)
-        const toApprove = unapproved.filter(post => voters.includes(post.author))
-        console.log('- approving', toApprove)
-        this._database.approve(toApprove)
+        const permlink = `${this.communityName}-week-${this.week}`;
+        const weekPost = await this._blockchainAPI.getPost({ author: this.username, permlink } as Post);
+        const voters = weekPost.active_votes.map(vote => vote.voter);
+        const toApprove = unapproved.filter((post: Post) => voters.includes(post.author));
+        console.log('- approving', toApprove.map(post => `${post.author}, ${post.permlink}`));
+        this._database.approve(toApprove);
 
 
     }
 
-    async comment(): Promise<any> {
+    public async comment(): Promise<void> {
         try {
             const allPosts = await this._database.getPosts()
 
-            const toCommentPosts = allPosts.filter(post => !post.did_comment && post.is_approved)
+            const toCommentPosts = allPosts
+                .filter(post => post.author !== this.username)
+                .filter(post => !post.did_comment && post.is_approved)
             console.log('- commenting on', toCommentPosts)
 
             // Comment on each one with 20 second breaks
             toCommentPosts.forEach((post, index) => {
                 setTimeout(async () => {
                     try {
-                        await this._broadcaster.makeComment(post)
-                        await this._database.writeComment(post)
+                        await this._broadcaster.makeComment(post);
+                        await this._database.writeComment(post);
                     } catch(e) {
-                        console.log('err commenting', e)
+                        console.log('err commenting', e);
                     }
                 }, index * 22 * 1000)
             })
         } catch(e) {
-            console.log('something went wrong', e)
+            console.log('something went wrong', e);
         }
     }
 
@@ -113,7 +114,9 @@ export class Bot {
         try {
             const allPosts = await this._database.getPosts()
             // Only vote on approved posts
-            const toVotePosts = allPosts.filter(post => !post.did_vote && post.is_approved)
+            const toVotePosts = allPosts
+                .filter(post => post.author !== this.username)
+                .filter(post => !post.did_vote && post.is_approved)
             console.log('- voting on', toVotePosts)
 
             // Vote on each one with 5 second breaks
@@ -132,31 +135,59 @@ export class Bot {
         }
     }
 
-    async payout(totalPayout: number): Promise<any> {
+    public async payout(totalPayout: number): Promise<void> {
         const allUsers = await this._database.getUsers()
-        const weekUsers = allUsers.filter(weekFilter(this.week))
-        console.log(weekUsers.map(u => u.username))
-        const wallet = await this._blockchainAPI.getWallet({ username: this.username } as User)
-        wallet.setActive(this.getActiveWif())
+        const weekUsers = allUsers.filter(weekFilter(this.week));
+        console.log(weekUsers.map(u => u.username));
+        const wallet = await this._blockchainAPI.getWallet({ username: this.username } as User);
+        wallet.setActive(this.getActiveWif());
+        wallet.setDanger(true);
 
         // Payout each user
         const individualPayout = totalPayout / weekUsers.length
         let current = 0;
-        weekUsers.forEach((user, index) => {
-            setTimeout(async () => {
-                try {
-                    await wallet.powerUp(user, individualPayout)
-                    current += individualPayout
-                    console.log(`${current.toFixed(3)}/${totalPayout} STEEM, [${index+1}/${weekUsers.length}] transactions complete...`)
-                } catch(e) {
-                    console.log('ran into an error')
-                    console.log('~~~~~', user, index)
-                    console.log(e)
-                }
-            }, index * 1000)
+        weekUsers.forEach((user: User, index: number) => {
+            setTimeout(
+                async () => {
+                    try {
+                        await wallet.powerUp(user, individualPayout);
+                        current += individualPayout;
+                        console.log(`${current.toFixed(3)}/${totalPayout} STEEM, [${index + 1}/${weekUsers.length}] transactions complete...`);
+                    } catch (e) {
+                        console.log('ran into an error');
+                        console.log('~~~~~', user, index);
+                        console.log(e);
+                    }
+                },
+                index * 1000);
             // 1 second delay between transaction
         })
+    }
 
+    public async makePost(): Promise<void> {
+        console.log(`[Should I Make a Post? - Week ${this.week}]`);
+        const posts = (await this._database.getPosts())
+            .filter((post: Post) => post.author === this.username);
+        const thisWeekPost = posts.find((post: Post) => post.permlink === `${this.communityName}-week-${this.week}`);
+        if (!thisWeekPost) {
+            console.log('Need to post a week');
+            await this.postWeek();
+        } else {
+            console.log('Good for this post');
+        }
+
+        const thisWeekPayout = posts.find((post: Post) => post.permlink === `${this.communityName}-recap-week-${this.week - 1}`);
+        if (!thisWeekPayout) {
+            if (new Date().getDay() > 3) {
+                console.log('Need to post a recap');
+                await this.postRecap();
+            } else {
+                console.log('ill do it later')
+            }
+        } else {
+            console.log('Good for this recap');
+        }
+        return;
     }
 
     async postWeek(): Promise<Report> {
@@ -174,13 +205,15 @@ export class Bot {
 
     async postRecap(): Promise<Report> {
         try {
-            const users = await this._database.getUsers()
-            const report = await reportRecap(users)
-            // this._broadcaster.makePost(report.post)
-            return report
+            const users = await this._database.getUsers();
+            const report = await reportRecap(users);
+            // this._broadcaster.makePost(report.post);
+
+            return report;
         } catch(e) {
             console.log(e)
-            console.log('got err')
+            console.log('got err');
+
             return null
         }
     }
@@ -208,14 +241,16 @@ export class Bot {
         })
     }
 
+    public async authenticate() {
+        const auth = await this._database.getSpotifyAuth();
+        const spotify = Spotify.Instance();
+        const updatedAuth = await spotify.authenticate(auth, this._database.writeSpotifyAuth);
+        return updatedAuth
+    }
+
     async replies() {
         try {
             const spotify = Spotify.Instance()
-            const authenticated = await spotify.authenticate()
-            if (!authenticated) {
-                console.log('bad authentication')
-                return
-            }
 
             const playlists = await spotify.getPlaylists()
             const playlist = playlists.find(playlist => playlist.week === this.week)
@@ -268,7 +303,6 @@ export class Bot {
                     }
                 }
             }
-            console.log('done with all posts')
         } catch(e) {
             process.exit()
             console.log('something went wrong', e)

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -7,7 +7,9 @@ export interface IDatabase {
     close: () => Promise<void>;
     getUsers: () => Promise<User[]>;
     getPosts: () => Promise<Post[]>;
-    
+    getSpotifyAuth: () => Promise<String>;
+
+    writeSpotifyAuth: (auth: { spotify_access: String, spotify_refresh: String }) => Promise<String>;
     approve: (post: Post[]) => Promise<any>;
     writePosts: (posts: Post[]) => Promise<{ created: number, updated: number, total: number }>;
     writeComment: (post: Post) => Promise<any>;

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -1,16 +1,16 @@
-import { User } from '../classes/user';
 import { Post } from '../classes/post';
 import { Track } from '../classes/track';
+import { User } from '../classes/user';
 
-export interface Database {
-    setup: () => Promise<void>
-    close: () => Promise<void>
-    getUsers: () => Promise<User[]>
-    getPosts: () => Promise<Post[]>
+export interface IDatabase {
+    setup: () => Promise<void>;
+    close: () => Promise<void>;
+    getUsers: () => Promise<User[]>;
+    getPosts: () => Promise<Post[]>;
     
-    approve: (post: Post[]) => Promise<any>
-    writePosts: (posts: Post[]) => Promise<{ created: number, updated: number, total: number }>
-    writeComment: (post: Post) => Promise<any>
-    writeVote: (post: Post) => Promise<any>
-    writeTrack: (track: Track) => Promise<any>
+    approve: (post: Post[]) => Promise<any>;
+    writePosts: (posts: Post[]) => Promise<{ created: number, updated: number, total: number }>;
+    writeComment: (post: Post) => Promise<any>;
+    writeVote: (post: Post) => Promise<any>;
+    writeTrack: (track: Track) => Promise<any>;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,7 @@ const main = async () => {
   const TIME = 1000 * 60 * 30
   const bot = new Bot()
   bot.communityName = settings.communityName
-  bot.week = settings.week
+  bot.week = settings.week()
   bot.username = settings.username
   bot.password = settings.password
   bot.setBroadcaster(new SteemBroadcaster())

--- a/src/process/init.ts
+++ b/src/process/init.ts
@@ -5,6 +5,7 @@ import { SteemBroadcaster } from '../broadcaster/steemBroadcaster';
 import { sqlDatabase } from '../database/sqlDatabase';
 import { SteemAPI } from '../blockchainAPI/steemAPI';
 import { settings } from '../settings';
+import { Spotify } from './spotify';
 
 const local = {
   host: process.env.DB_HOST || '127.0.0.1',
@@ -22,5 +23,7 @@ export const init = async () => {
   bot.setBroadcaster(new SteemBroadcaster())
   bot.setBlockchainAPI(new SteemAPI())
   await bot.setDatabase(new sqlDatabase(local))
+  await bot.authenticate()
+
   return bot
 }

--- a/src/process/init.ts
+++ b/src/process/init.ts
@@ -16,7 +16,7 @@ const local = {
 export const init = async () => {
   const bot = new Bot()
   bot.communityName = settings.communityName
-  bot.week = settings.week
+  bot.week = settings.week()
   bot.username = settings.username
   bot.password = settings.password
   bot.setBroadcaster(new SteemBroadcaster())

--- a/src/process/makePosts.ts
+++ b/src/process/makePosts.ts
@@ -1,11 +1,12 @@
-import { init } from './init'
 import { Bot } from '../bot';
 import { settings } from '../settings';
+import { init } from './init';
 
 const main = async () => {
-    const bot: Bot = await init()
-    await bot.payout(settings.payout)
-    bot.close()
-}
+    const bot: Bot = await init();
+    await bot.makePost();
+    bot.close();
+    process.exit()
+};
 
-main()
+main();

--- a/src/process/makePosts.ts
+++ b/src/process/makePosts.ts
@@ -1,0 +1,11 @@
+import { init } from './init'
+import { Bot } from '../bot';
+import { settings } from '../settings';
+
+const main = async () => {
+    const bot: Bot = await init()
+    await bot.payout(settings.payout)
+    bot.close()
+}
+
+main()

--- a/src/process/payout.ts
+++ b/src/process/payout.ts
@@ -4,7 +4,7 @@ import { settings } from '../settings';
 
 const main = async () => {
     const bot: Bot = await init()
-    bot.payout(settings.payout)
+    await bot.payout(settings.payout)
     bot.close()
 }
 

--- a/src/process/payout.ts
+++ b/src/process/payout.ts
@@ -5,6 +5,7 @@ import { settings } from '../settings';
 const main = async () => {
     const bot: Bot = await init()
     bot.payout(settings.payout)
+    bot.close()
 }
 
 main()

--- a/src/process/postRecap.ts
+++ b/src/process/postRecap.ts
@@ -7,6 +7,7 @@ const main = async () => {
     const report = await bot.postRecap()
     // console.log(report)
     ncp.copy(report.post.body, () => console.log('Copied to clipboard'))
+    bot.close()
 }
 
 main()

--- a/src/process/postWeek.ts
+++ b/src/process/postWeek.ts
@@ -7,6 +7,7 @@ const main = async () => {
     const report = await bot.postWeek()
     // console.log(report)
     ncp.copy(report.post.body, () => console.log('Copied to clipboard'))
+    bot.close()
 }
 
 main()

--- a/src/process/replies.ts
+++ b/src/process/replies.ts
@@ -4,6 +4,7 @@ import { Bot } from '../bot';
 const main = async () => {
     const bot: Bot = await init()
     bot.replies()
+    bot.close()
 }
 
 main()

--- a/src/process/replies.ts
+++ b/src/process/replies.ts
@@ -3,7 +3,7 @@ import { Bot } from '../bot';
 
 const main = async () => {
     const bot: Bot = await init()
-    bot.replies()
+    await bot.replies()
     bot.close()
 }
 

--- a/src/process/scrape.ts
+++ b/src/process/scrape.ts
@@ -5,6 +5,7 @@ import { Bot } from '../bot';
 const main = async () => {
     const bot: Bot = await init()
     bot.scrape()
+    bot.close()
 }
 
 main()

--- a/src/process/scrape.ts
+++ b/src/process/scrape.ts
@@ -4,7 +4,7 @@ import { Bot } from '../bot';
 
 const main = async () => {
     const bot: Bot = await init()
-    bot.scrape()
+    await bot.scrape()
     bot.close()
 }
 

--- a/src/process/stats.ts
+++ b/src/process/stats.ts
@@ -1,0 +1,11 @@
+import { init } from './init'
+import { Bot } from '../bot';
+
+
+const main = async () => {
+    const bot: Bot = await init()
+    await bot.stats()
+    bot.close()
+}
+
+main()

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -93,7 +93,7 @@ export const leaderboard = (report: Report): Report => {
 
 export const initializeReport = (users: User[], postWeek = false): Report => {
     const report = new Report()
-    report.reportOptions.week = settings.week()
+    report.reportOptions.week = settings.week() - 1
     report.reportOptions.startWeek = new Date(2018, 0, (report.reportOptions.week - 1) * 7)
     report.reportOptions.endWeek = new Date(2018, 0, (report.reportOptions.week) * 7 - 1)
     report.reportOptions.payout = settings.payout

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -93,7 +93,7 @@ export const leaderboard = (report: Report): Report => {
 
 export const initializeReport = (users: User[], postWeek = false): Report => {
     const report = new Report()
-    report.reportOptions.week = settings.week - 1
+    report.reportOptions.week = settings.week
     report.reportOptions.startWeek = new Date(2018, 0, (report.reportOptions.week - 1) * 7)
     report.reportOptions.endWeek = new Date(2018, 0, (report.reportOptions.week) * 7 - 1)
     report.reportOptions.payout = settings.payout

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -75,13 +75,13 @@ export const spotify = (report: Report): Report => {
 }
 
 export const payout = (report: Report): Report => {
-    const users = report.users.filter(weekFilter(settings.week - 1))
+    const users = report.users.filter(weekFilter(settings.week() - 1))
     report.post.body = `${report.post.body}\n${center(`Week ${report.reportOptions.week} Contestants`)}\n${center(`We had a total payout of about ${report.reportOptions.payout} STEEM, which will be powered up to all ${users.length} contestants.  That's about ${parseInt(String(report.reportOptions.payout / users.length * 1000)) / 1000} SP per person!`)}`
     return report
 }
 
 export const contestants = (report: Report): Report => {
-    const users = report.users.filter(weekFilter(settings.week - 1))
+    const users = report.users.filter(weekFilter(settings.week() - 1))
     report.post.body = `${report.post.body}\n${center(`${users.reduce((str, user, index) => `${str}[${user.username}](steemit.com/nowplaying/@${user.username}/${user.posts[user.posts.length - 1].permlink})${index === users.length-1 ? '!' : ', '}`, '')}`)}`
     return report
 }
@@ -93,7 +93,7 @@ export const leaderboard = (report: Report): Report => {
 
 export const initializeReport = (users: User[], postWeek = false): Report => {
     const report = new Report()
-    report.reportOptions.week = settings.week
+    report.reportOptions.week = settings.week()
     report.reportOptions.startWeek = new Date(2018, 0, (report.reportOptions.week - 1) * 7)
     report.reportOptions.endWeek = new Date(2018, 0, (report.reportOptions.week) * 7 - 1)
     report.reportOptions.payout = settings.payout

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -21,35 +21,38 @@ export const getRankings = (report: Report): string => report.users
     .map(user => ({
         username: `@${user.username}`,
         weeks: getNumWeeks(user.posts),
-        votes: getNumVotes(user.posts)
+        votes: Math.floor(getNumVotes(user.posts) / user.posts.length + 0.5),
     }))
     // Sort by weeks, then votes
     .sort((a, b) => b.weeks - a.weeks || b.votes - a.votes)
     // Reduce into one large string
-    .reduce((str, user, index) => `${str}\n${index+1} | ${user.username} | ${user.weeks} | ${user.votes}`, '')
+    .reduce((str, user, index) => `${str}\n${index+1} | ${user.username} | ${user.weeks} | ${user.votes}`, '');
 
-// export const playerStats = (users: User[], username: string) => getRankings({ users, reportOptions: { week: 5}} as Report).find(x => x.author === username).text
-    // getRankings({users, reportOptions: {week: 5}} as Report).find(str => str.includes(`@${username}`))
-
-export const center = (str: string) => `<center>${str}</center>`
+export const center = (str: string) => `<center>${str}</center>`;
 
 export const startTitle = (report: Report): Report => {
     report.post.body = `${report.post.body}# ${center(`Now Playing: Week ${report.reportOptions.week} (${dateformat(report.reportOptions.startWeek, 'mmm d')} - ${dateformat(report.reportOptions.endWeek, 'mmm d')})`)}`
-    return report
-}
+
+    return report;
+};
+
 export const endTitle = (report: Report): Report => {
     report.post.body = `${report.post.body}# ${center(`Now Playing Recap: Week ${report.reportOptions.week} (${dateformat(report.reportOptions.startWeek, 'mmm d')} - ${dateformat(report.reportOptions.endWeek, 'mmm d')})`)}`
-    return report
-}
+
+    return report;
+};
 
 export const subtitle = (report: Report): Report => {
     report.post.body = `${report.post.body}\n${center(`\`Now Playing\` is a way to share what you're listening to this week with others.`)}`
-    return report
-}
+
+    return report;
+};
+
 export const logo = (report: Report): Report => {
     report.post.body = `${report.post.body}\n![](https://steemitimages.com/DQmeUqpd5RJbEUEkdTHqYBZYmcA137fUq4FX5nTN6yBuscW/image.png)`
-    return report
-}
+
+    return report;
+};
 
 export const rules = (report: Report): Report => {
     report.post.body = `${report.post.body}\n## <center>Steemit Now Playing Rules</center>
@@ -65,14 +68,16 @@ export const rules = (report: Report): Report => {
 | Rewards from this post will be split among all contributors equally
 | -
 | A contributor is anyone who follows all of the above rules
-`
-    return report
-}
+`;
+
+    return report;
+};
 
 export const spotify = (report: Report): Report => {
     report.post.body = `${report.post.body}\n## ${center(`[Spotify Playlist](${report.reportOptions.spotifyLink})`)}\n${center(`[![](${report.reportOptions.spotifyImg})](${report.reportOptions.spotifyLink})`)}`
-    return report
-}
+
+    return report;
+};
 
 export const payout = (report: Report): Report => {
     const users = report.users.filter(weekFilter(settings.week() - 1))
@@ -87,9 +92,10 @@ export const contestants = (report: Report): Report => {
 }
 
 export const leaderboard = (report: Report): Report => {
-    report.post.body = `${report.post.body}\n## ${center(`Leaderboards`)}\nRank | User | Weeks | Votes\n-|-|-|-${getRankings(report)}`
-    return report
-}
+    report.post.body = `${report.post.body}\n## ${center(`Leaderboards`)}\nRank | User | Weeks | Votes (per post)\n-|-|-|-${getRankings(report)}`;
+
+    return report;
+};
 
 export const initializeReport = (users: User[], postWeek = false): Report => {
     const report = new Report()

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,7 +4,7 @@ export const settings = {
     communityName: 'nowplaying',
     username: process.env.STEEM_USERNAME,
     password: process.env.STEEM_PASSWORD,
-    week: () => isTest ? 10 : Math.ceil(((((new Date() as any) - (new Date(2018, 0, 1) as any)) / 86400000) ) / 7) + 1,
+    week: () => isTest ? 10 : Math.ceil(((((new Date() as any) - (new Date(2018, 0, 1) as any)) / 86400000) ) / 7),
     payout: 0.4,
     tags: ['nowplaying', 'music', 'contest', 'share', 'spotify'],
     blacklist: [

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -5,7 +5,7 @@ export const settings = {
     username: process.env.STEEM_USERNAME,
     password: process.env.STEEM_PASSWORD,
     week: () => isTest ? 10 : Math.ceil(((((new Date() as any) - (new Date(2018, 0, 1) as any)) / 86400000) ) / 7),
-    payout: 0.4,
+    payout: 0.99,
     tags: ['nowplaying', 'music', 'contest', 'share', 'spotify'],
     blacklist: [
         'arsaljr',
@@ -17,7 +17,6 @@ export const settings = {
         'loubega',
         'maulinda',
         'moontrap',
-        'nowplaying-music',
         'rahmatz',
         'ryanananda',
         'safrizalpotret',
@@ -25,8 +24,8 @@ export const settings = {
     ],
 
     // Spotify
-    spotifyLink: 'https://open.spotify.com/user/1240132288/playlist/0zOxW1tvzXkNUXtlfMIV5C?si=gFlNl8WxRX6Tsc8QF-ffAw',
-    spotifyImg: 'https://steemitimages.com/DQmXpCkcSg6oZE9ucEiQHvAFJmQj2iWzidGjrHWYpKMDVnb/image.png',
+    spotifyLink: 'https://open.spotify.com/user/1240132288/playlist/5SbUiRIpH2dQ7q2wXuc0Qp?si=rOopOVUVTa6iSNUmYU6upg',
+    spotifyImg: 'https://steemitimages.com/DQmRVimTJm1cffUjuLDfSoRAFknghH885zqSS6xd3n8cyGd/image.png',
     spotifyUserId: 1240132288,
 
     commentBody: `Thanks for entering this week's #nowplaying!\nIf you would like your song added to the weekly spotify playlist, reply to this comment in the following format:\n\`\`\`\nArtist\nSong\n\`\`\`\nIf you have multiple songs, make multiple replies to this comment`,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,7 +4,7 @@ export const settings = {
     communityName: 'nowplaying',
     username: process.env.STEEM_USERNAME,
     password: process.env.STEEM_PASSWORD,
-    week: isTest ? 10 : Math.ceil(((((new Date() as any) - (new Date(2018, 0, 1) as any)) / 86400000) ) / 7) + 1,
+    week: () => isTest ? 10 : Math.ceil(((((new Date() as any) - (new Date(2018, 0, 1) as any)) / 86400000) ) / 7) + 1,
     payout: 0.4,
     tags: ['nowplaying', 'music', 'contest', 'share', 'spotify'],
     blacklist: [

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,7 +4,7 @@ export const settings = {
     communityName: 'nowplaying',
     username: process.env.STEEM_USERNAME,
     password: process.env.STEEM_PASSWORD,
-    week: isTest ? 10 : Math.ceil(((((new Date() as any) - (new Date(2018, 0, 1) as any)) / 86400000) ) / 7),
+    week: isTest ? 10 : Math.ceil(((((new Date() as any) - (new Date(2018, 0, 1) as any)) / 86400000) ) / 7) + 1,
     payout: 0.4,
     tags: ['nowplaying', 'music', 'contest', 'share', 'spotify'],
     blacklist: [

--- a/src/statistics.ts
+++ b/src/statistics.ts
@@ -31,14 +31,14 @@ export class Statistics {
     }
 
     public general() {
-        console.log('posts: ', this._posts.length)
-        console.log('users: ', this._users.length)
+        console.log('posts: ', this._posts.length);
+        console.log('users: ', this._users.length);
         const weeks = [...Array(settings.week() + 1).keys()]
             .map((weekNum: Number) => ({ weekNum, posts: this._posts.filter(postWeekFilter(weekNum))}))
             .map(week => ({ length: week.posts.length, posts: week.posts, weekNum: week.weekNum }))
             .map(week => ({
                 ...week,
-                votes: week.posts.map(p => p.votes).reduce((p, c) => p + c, 0),
+                votes: week.posts.map((post: Post) => p.votes).reduce((p, c) => p + c, 0),
                 authors: week.posts
                     .map((post: Post) => post.author)
                     .filter((author: String, index: Number, authors: String[]) => authors.indexOf(author) === index),

--- a/src/statistics.ts
+++ b/src/statistics.ts
@@ -34,7 +34,7 @@ export class Statistics {
     public general() {
         console.log('posts: ', this._posts.length)
         console.log('users: ', this._users.length)
-        const weeks = [...Array(settings.week + 1).keys()]
+        const weeks = [...Array(settings.week() + 1).keys()]
             .map(weekNum => ({ weekNum, posts: this._posts.filter(postWeekFilter(weekNum))}))
             .map(week => ({ length: week.posts.length, posts: week.posts, weekNum: week.weekNum }))
             .map(week => ({

--- a/src/statistics.ts
+++ b/src/statistics.ts
@@ -1,6 +1,6 @@
-import { postWeekFilter } from './filters';
 import { Post } from './classes/post';
 import { User } from './classes/user';
+import { postWeekFilter } from './filters';
 import { settings } from './settings';
 
 export class Statistics {
@@ -8,8 +8,7 @@ export class Statistics {
     private _users: User[] = [];
     private _posts: Post[] = [];
 
-    private constructor() {   
-    }
+    private constructor() { }
 
     public static Instance(): Statistics {
         // check if an instance of the class is already created
@@ -19,33 +18,35 @@ export class Statistics {
             this.statistics = new Statistics();
         }
         // return the singleton object
-        return this.statistics
+
+        return this.statistics;
     }
 
+    public set users(value: User[]) {
+        this._users = value;
+    }
 
-	public set users(value: User[] ) {
-		this._users = value;
-	}
+    public set posts(value: Post[]) {
+        this._posts = value;
+    }
 
-	public set posts(value: Post[] ) {
-		this._posts = value;
-	}
-    
     public general() {
         console.log('posts: ', this._posts.length)
         console.log('users: ', this._users.length)
         const weeks = [...Array(settings.week() + 1).keys()]
-            .map(weekNum => ({ weekNum, posts: this._posts.filter(postWeekFilter(weekNum))}))
+            .map((weekNum: Number) => ({ weekNum, posts: this._posts.filter(postWeekFilter(weekNum))}))
             .map(week => ({ length: week.posts.length, posts: week.posts, weekNum: week.weekNum }))
             .map(week => ({
                 ...week,
                 votes: week.posts.map(p => p.votes).reduce((p, c) => p + c, 0),
                 authors: week.posts
-                    .map(post => post.author)
-                    .filter((author, index, authors) => authors.indexOf(author) === index)
-                })
-            )
-            
-        console.log(weeks.map(week => `Week ${week.weekNum} had ${week.length} entries with ${week.authors.length} users and ${week.votes} total votes!`))
+                    .map((post: Post) => post.author)
+                    .filter((author: String, index: Number, authors: String[]) => authors.indexOf(author) === index),
+                }),
+            );
+
+        console.log(weeks.map(week =>
+            `Week ${week.weekNum} had ${week.length} entries with ${week.authors.length} users and ${week.votes} total votes!`,
+        ));
     }
 }

--- a/src/statistics.ts
+++ b/src/statistics.ts
@@ -38,7 +38,7 @@ export class Statistics {
             .map(week => ({ length: week.posts.length, posts: week.posts, weekNum: week.weekNum }))
             .map(week => ({
                 ...week,
-                votes: week.posts.map((post: Post) => p.votes).reduce((p, c) => p + c, 0),
+                votes: week.posts.map((post: Post) => post.votes).reduce((p, c) => p + c, 0),
                 authors: week.posts
                     .map((post: Post) => post.author)
                     .filter((author: String, index: Number, authors: String[]) => authors.indexOf(author) === index),

--- a/tables.sql
+++ b/tables.sql
@@ -7,7 +7,7 @@
 #
 # Host: 216.15.29.240 (MySQL 5.7.18-0ubuntu0.17.04.1)
 # Database: nowplaying
-# Generation Time: 2018-03-30 15:27:15 +0000
+# Generation Time: 2018-04-30 16:18:35 +0000
 # ************************************************************
 
 
@@ -22,8 +22,6 @@
 
 # Dump of table posts
 # ------------------------------------------------------------
-
-USE nowplaying;
 
 CREATE TABLE `posts` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -41,6 +39,18 @@ CREATE TABLE `posts` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `author` (`author`,`permlink`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+# Dump of table settings
+# ------------------------------------------------------------
+
+CREATE TABLE `settings` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `spotify_refresh` varchar(512) DEFAULT NULL,
+  `spotify_access` varchar(512) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 
 

--- a/tables.sql
+++ b/tables.sql
@@ -23,6 +23,8 @@
 # Dump of table posts
 # ------------------------------------------------------------
 
+USE nowplaying;
+
 CREATE TABLE `posts` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `author` varchar(20) NOT NULL DEFAULT '',

--- a/tslint.json
+++ b/tslint.json
@@ -8,7 +8,7 @@
     "tslint-microsoft-contrib"
   ],
   "rules": {
-    "indent": [true, "spaces", 4],
+    "indent": [true, "spaces", 4]
     "mocha-no-side-effect-code": false,
     "missing-jsdoc": false,
     "no-relative-imports": false,

--- a/tslint.json
+++ b/tslint.json
@@ -8,13 +8,17 @@
     "tslint-microsoft-contrib"
   ],
   "rules": {
+    "indent": [true, "spaces", 4],
     "mocha-no-side-effect-code": false,
     "missing-jsdoc": false,
     "no-relative-imports": false,
     "export-name": false,
     "promise-function-async": false,
+    "function-name": false,
+    "no-console": false,
     "no-void-expression": false,
     "no-redundant-jsdoc": false,
+    "completed-docs": false,
     "trailing-comma": [ // https://palantir.github.io/tslint/rules/trailing-comma/
       true,
       {


### PR DESCRIPTION
### New Features
#### Automatic Posting #53 
This pull request implements "Automatic Posting".  This introduces a way for nowplaying to continually stay up to date without someone triggering the weekly posts manually.  Originally it was to be a cron job run at a specific time, however it was implemented as a polling system that way if a certain time was missed it would simply post the next iteration.

Posts are scheduled to go up when the week changes.  This happens Saturday night/Sunday morning and the new week's post should be added automatically.  The code first looks for this week's post, and if it can't find it it will create the post.  If the post exists then the function exits.

We can expect some time until the recap posts are working correctly because they require a manual input of the `payout`.  I would also like to test that thoroughly before using it because it sends out steem power to participants which is something we don't want to mess up.

#### Saved Spotify Credentials
Spotify authentication was moved to the database, this allows us to not have to refresh the authentication every time we run the program.  The database saves both an access token and a refresh token to be used with the API to fetch and manipulate spotify playlists.  This creates an entirely new table in the database called `settings`, which holds important information that may vary depending on your database.  In this case the spotify credentials are information that is aligned with the database.

### Now Playing
Check out the #nowplaying community and bot in action [here](https://steemit.com/nowplaying/@nowplaying-music/nowplaying-week-13)
![image](https://user-images.githubusercontent.com/9692067/39495800-de9f4b4a-4d69-11e8-9195-d49f4ed7a324.png)

